### PR TITLE
fix(*): restore babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  presets: [
+    '@babel/preset-react',
+    [
+      '@babel/preset-typescript',
+      {
+        isTSX: true,
+        allExtensions: true
+      }
+    ]
+  ]
+};


### PR DESCRIPTION
# Опишите проблему
Фейлится сборка пакета. Выводится след. ошибка:
```
Error: Babel was run with rootMode:"upward" but a root could not be found when searching upward from "/Users/alexyatsenko/projects/core-components/packages/button".
One of the following config files must be in the directory tree: "babel.config.js, babel.config.cjs, babel.config.mjs, babel.config.json".
```

# Шаги для воспроизведения
Запустить `yarn build`

# Ожидаемое поведение
Пакет должен собираться.

# Решение
Вернул конфиг babel'а, который был удален [тут](https://github.com/alfa-laboratory/core-components/commit/3bd5492bba179083cb26aa99c295a43f8e3be037#diff-fc10a6682269c1fefc2abe05d1500b8a)
