### PR TITLE
feat(*): post storybook url to PR after push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,8 @@ jobs:
         git push -q -f "https://alfa-bot:${{ secrets.BOT_AUTH_TOKEN }}@github.com/alfa-laboratory/core-components.git" master:gh-pages
 
     # Ищем открытый PR
-    - uses: jwalton/gh-find-current-pr@v1
+    - name: Find open PR
+      uses: jwalton/gh-find-current-pr@v1
       id: find_pr
       with:
         github-token: ${{ secrets.BOT_AUTH_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,28 @@ jobs:
     #   run: yarn test
 
     - name: Run build
+      id: demo_build
       run: node ./bin/demo-build.js
 
     - name: Publish storybook
       run: |
         cd ./storybook-demo
         git push -q -f "https://alfa-bot:${{ secrets.BOT_AUTH_TOKEN }}@github.com/alfa-laboratory/core-components.git" master:gh-pages
+
+    # Ищем открытый PR
+    - uses: jwalton/gh-find-current-pr@v1
+        id: find_pr
+        with:
+          github-token: ${{ secrets.BOT_AUTH_TOKEN }}
+
+    # Если нашли открытый PR, то добавляем коммент с ссылкой на демку.
+    # storybook_url заполняется в demo-build.js
+    - name: Create comment
+      if: success() && steps.find_pr.outputs.number
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        token: ${{ secrets.BOT_AUTH_TOKEN }}
+        issue-number: ${{ steps.find_pr.outputs.pr }}
+        body: |
+          Собрана новая [демка](${{ steps.demo_build.outputs.storybook_url }}).
+        reaction-type: 'rocket'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,9 @@ jobs:
 
     # Ищем открытый PR
     - uses: jwalton/gh-find-current-pr@v1
-        id: find_pr
-        with:
-          github-token: ${{ secrets.BOT_AUTH_TOKEN }}
+      id: find_pr
+      with:
+        github-token: ${{ secrets.BOT_AUTH_TOKEN }}
 
     # Если нашли открытый PR, то добавляем коммент с ссылкой на демку.
     # storybook_url заполняется в demo-build.js

--- a/bin/demo-build.js
+++ b/bin/demo-build.js
@@ -76,8 +76,9 @@ shell.exec('git add .', execOptions);
 shell.exec(`git commit -m "${defaultConfig.commitMessage}"`, execOptions);
 
 // log output url
-if (sourceBranch === 'master') {
-  console.log(`=> Storybook deployed to: ${gitPagesUrl}/master/`);
-} else {
-  console.log(`=> Storybook deployed to: ${gitPagesUrl}/${tempOutputDir}/`);
-}
+const storybookUrl = `${gitPagesUrl}/${sourceBranch === 'master' ? 'master' : tempOutputDir}/`;
+
+console.log(`=> Storybook deployed to: ${storybookUrl}`);
+
+// store storybook url
+shell.exec(`echo ::set-output name=storybook_url::${storybookUrl}`);


### PR DESCRIPTION
Теперь ссылка на сторибук публикуется автоматически после пуша.

- ссылка на сторибук после сборки сохраняется в `steps.demo_build.outputs.storybook_url`
- скрипт ищет открытый PR
- если PR есть, то бот оставляет коммент с ссылкой на демку