### PR TITLE
fix(build-root-package): several hyphens in dir name

### DIFF
--- a/bin/build-root-package.sh
+++ b/bin/build-root-package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # название подпакета => @alfalab/core-components-button => button = package_name
-package_name=$(echo $1 | awk -F- '{print $3}')
+package_name=$(echo $1 | awk -F "@alfalab/core-components-" '{print $2}')
 # создаю дерикторию в корне проекта
 mkdir -p ../../dist/$package_name
 # копирую собранный подпакет в корневую сборку


### PR DESCRIPTION
# Опишите проблему

build-root-package.sh некорректно обрабатывает пакеты с дефисами в названии папки.

# Шаги для воспроизведения
1. Назвать папку с пакетом через дефис. Например `pure-input`
2. Запустить `yarn build`
3. В папке `/dist` появится папка `pure`

# Ожидаемое поведение

Папка должна называться `pure-input`
