### PR TITLE
refactor(*): replace type --> view. htmlType --> type.

### DIFF
--- a/src/button/src/Component.stories.tsx
+++ b/src/button/src/Component.stories.tsx
@@ -33,14 +33,14 @@ export const ButtonStory = () => (
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
                 <Button
-                    type={select(
-                        'Type',
+                    view={select(
+                        'View',
                         ['primary', 'secondary', 'outlined', 'link', 'ghost'],
                         'primary',
                     )}
                     title={text('Title', '')}
                     disabled={boolean('Disabled', false)}
-                    htmlType={select('htmlType', ['button', 'reset', 'submit'], 'button')}
+                    type={select('type', ['button', 'reset', 'submit'], 'button')}
                     href={text('href', '')}
                     size={select('Size', ['xs', 's', 'm', 'l'], 'm')}
                     block={boolean('Block', false)}
@@ -54,33 +54,33 @@ export const ButtonStory = () => (
         </div>
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
-                <Button type='secondary' leftAddons={icon} size='m'>
+                <Button view='secondary' leftAddons={icon} size='m'>
                     Secondary
                 </Button>
             </div>
         </div>
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
-                <Button type='secondary' rightAddons={icon} size='m' />
+                <Button view='secondary' rightAddons={icon} size='m' />
             </div>
         </div>
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
-                <Button type='outlined' size='m'>
+                <Button view='outlined' size='m'>
                     Outlined
                 </Button>
             </div>
         </div>
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
-                <Button type='link' size='m'>
+                <Button view='link' size='m'>
                     Link
                 </Button>
             </div>
         </div>
         <div className={cn(styles.row)}>
             <div className={cn(styles.col)}>
-                <Button type='ghost' size='m'>
+                <Button view='ghost' size='m'>
                     Ghost
                 </Button>
             </div>

--- a/src/button/src/Component.tsx
+++ b/src/button/src/Component.tsx
@@ -17,10 +17,7 @@ import styles from './index.module.css';
 
 type ComponentProps = {
     /** Тип кнопки */
-    type?: 'primary' | 'secondary' | 'outlined' | 'link' | 'ghost';
-
-    /** Атрибут type */
-    htmlType?: 'button' | 'reset' | 'submit';
+    view?: 'primary' | 'secondary' | 'outlined' | 'link' | 'ghost';
 
     /** Слот слева */
     leftAddons?: React.ReactNode;
@@ -42,7 +39,7 @@ type ComponentProps = {
 };
 
 type AnchorButtonProps = ComponentProps & AnchorHTMLAttributes<HTMLAnchorElement>;
-type NativeButtonProps = ComponentProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'>;
+type NativeButtonProps = ComponentProps & ButtonHTMLAttributes<HTMLButtonElement>;
 type ButtonProps = Partial<AnchorButtonProps & NativeButtonProps>;
 
 /**
@@ -53,7 +50,7 @@ export const Button = React.forwardRef<HTMLAnchorElement & HTMLButtonElement, Bu
     (
         {
             children,
-            type = 'secondary',
+            view = 'secondary',
             leftAddons,
             rightAddons,
             size = 'm',
@@ -68,7 +65,7 @@ export const Button = React.forwardRef<HTMLAnchorElement & HTMLButtonElement, Bu
         const componentProps = {
             className: cn(
                 styles.component,
-                styles[type],
+                styles[view],
                 styles[size],
                 {
                     [styles.block]: block,
@@ -95,11 +92,9 @@ export const Button = React.forwardRef<HTMLAnchorElement & HTMLButtonElement, Bu
             );
         }
 
-        const { htmlType, ...buttonProps } = restProps;
-
         return (
             // eslint-disable-next-line react/button-has-type
-            <button {...componentProps} {...buttonProps} type={htmlType} ref={ref}>
+            <button {...componentProps} {...restProps} ref={ref}>
                 {buttonChildren}
             </button>
         );

--- a/src/input/src/Component.stories.tsx
+++ b/src/input/src/Component.stories.tsx
@@ -34,7 +34,7 @@ export const InputStory = () => {
 
     return (
         <Input
-            htmlType={select(
+            type={select(
                 'type',
                 ['number', 'card', 'email', 'money', 'password', 'tel', 'text'],
                 'text',

--- a/src/input/src/Component.tsx
+++ b/src/input/src/Component.tsx
@@ -15,7 +15,7 @@ import styles from './index.module.css';
  * Types
  */
 
-export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'> & {
     /** Растягивает компонент на ширину контейнера */
     block?: boolean;
 
@@ -32,7 +32,7 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
     label?: React.ReactNode;
 
     /** Атрибут type */
-    htmlType?: 'number' | 'card' | 'email' | 'money' | 'password' | 'tel' | 'text';
+    type?: 'number' | 'card' | 'email' | 'money' | 'password' | 'tel' | 'text';
 
     /** Слот слева */
     leftAddons?: React.ReactNode;
@@ -71,7 +71,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     (
         {
             size = 's',
-            htmlType = 'text',
+            type = 'text',
             block = false,
             bottomAddons,
             className,
@@ -147,7 +147,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                             onBlur={handleInputBlur}
                             onFocus={handleInputFocus}
                             ref={ref}
-                            type={htmlType}
+                            type={type}
                             value={value}
                             data-test-id={dataTestId}
                         />

--- a/src/pure-input/src/Component.stories.tsx
+++ b/src/pure-input/src/Component.stories.tsx
@@ -27,7 +27,7 @@ export const PureInputStory = () => {
     return (
         <PureInput
             size={select('size', ['s', 'm', 'l'], 's')}
-            htmlType={select(
+            type={select(
                 'type',
                 ['number', 'card', 'email', 'hidden', 'money', 'password', 'tel', 'text'],
                 'text',

--- a/src/pure-input/src/Component.tsx
+++ b/src/pure-input/src/Component.tsx
@@ -15,12 +15,12 @@ import styles from './index.module.css';
  * Types
  */
 
-export type PureInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+export type PureInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'> & {
     /** Растягивает компонент на ширину контейнера */
     block?: boolean;
 
     /** Атрибут type */
-    htmlType?: 'number' | 'card' | 'email' | 'hidden' | 'money' | 'password' | 'tel' | 'text';
+    type?: 'number' | 'card' | 'email' | 'hidden' | 'money' | 'password' | 'tel' | 'text';
 
     /** Размер компонента */
     size?: 's' | 'm' | 'l';
@@ -37,10 +37,7 @@ export type PureInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>
  */
 
 export const PureInput = React.forwardRef<HTMLInputElement, PureInputProps>(
-    (
-        { size = 's', htmlType = 'text', block = false, className, dataTestId, ...restProps },
-        ref,
-    ) => (
+    ({ size = 's', type = 'text', block = false, className, dataTestId, ...restProps }, ref) => (
         <input
             {...restProps}
             className={cn(
@@ -52,7 +49,7 @@ export const PureInput = React.forwardRef<HTMLInputElement, PureInputProps>(
                 className,
             )}
             ref={ref}
-            type={htmlType}
+            type={type}
             data-test-id={dataTestId}
         />
     ),


### PR DESCRIPTION
Предложение отказаться от использования нативных атрибутов не по назначению.

Поэтому `htmlType` теперь просто `type`.

У кнопки `type: 'primary' | 'secondary' | 'outlined' | 'link' | 'ghost'` переименован во `view`.

Название `view` приехало из фижера и должно быть привычным для всех. 
Также рассматривали следующие варианты вместо `view`:
- type (ant)
- kind (akit/ibm)
- appearance (atlassian)
- variant (material)