### PR TITLE
Документация типов пропсов в storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -38,8 +38,8 @@ const getBabelRules = ({ mode, withRDTL }) => {
         tsconfigPath: path.resolve(__dirname, '../tsconfig.storybook.json'),
         propFilter: (props, component) => {
           if (props.parent) {
-            // Показываем только пользовательские пропсы. (Иначе будет простыня из HTMLAttributes)
-            return !props.parent.fileName.includes('node_modules');
+            // Показываем только пользовательские пропсы и пропсы, помеченные как (native prop). (Иначе будет простыня из HTMLAttributes)
+            return !props.parent.fileName.includes('node_modules') || props.description.includes('(native prop)');
           } else {
             return true;
           }


### PR DESCRIPTION
Сейчас в документацию компонента в storybook попадают только пользовательские пропсы.

Пример:
```typescript
type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
    /** Слот слева */
    leftAddons?: React.ReactNode;
}
```

В storybook попадет один пропс: `leftAddons?: React.ReactNode`.

Хочется видеть в документации какие-то нативные пропсы тоже. По-этому предлагаю чем-то их помечать, например `(native prop)`:

```typescript
type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
    /** Слот слева */
    leftAddons?: React.ReactNode;

   /** Обработчик клика (native prop) */
    onClick: ButtonHTMLAttributes<HTMLButtonElement>['onChange'];
}
```
