### PR TITLE
fix(input): fix wrong filled state

### DIFF
--- a/packages/input/src/Component.stories.tsx
+++ b/packages/input/src/Component.stories.tsx
@@ -1,5 +1,5 @@
 import { withKnobs, select, text, boolean } from '@storybook/addon-knobs';
-import React, { useState } from 'react';
+import React from 'react';
 import { withDesign } from 'storybook-addon-designs';
 
 import { Input } from './Component';
@@ -19,11 +19,6 @@ const icon = (
 );
 
 export const InputStory = () => {
-    const [value, setValue] = useState('value');
-
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>): void =>
-        setValue(event.target.value);
-
     return (
         <Input
             type={select(
@@ -38,8 +33,6 @@ export const InputStory = () => {
             label={text('label', '')}
             hint={text('hint', '')}
             error={text('error', '')}
-            value={value}
-            onChange={handleChange}
             rightAddons={boolean('rightAddons', true) && !text('error', '') && icon}
         />
     );

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -92,6 +92,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             leftAddons,
             onFocus,
             onBlur,
+            onChange,
             rightAddons,
             value,
             ...restProps
@@ -99,6 +100,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref,
     ) => {
         const [focused, setFocused] = useState(false);
+        const [filled, setFilled] = useState(value !== undefined && value !== '');
 
         const handleInputFocus = (e: React.FocusEvent<HTMLInputElement>) => {
             setFocused(true);
@@ -113,6 +115,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
             if (onBlur) {
                 onBlur(e);
+            }
+        };
+
+        const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+            setFilled(e.target.value !== '');
+
+            if (onChange) {
+                onChange(e);
             }
         };
 
@@ -135,7 +145,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     {
                         [styles.focused]: focused,
                         [styles.disabled]: disabled,
-                        [styles.filled]: value,
+                        [styles.filled]: filled,
                         [styles.hasLabel]: label,
                         [styles.hasError]: error,
                         [styles.block]: block,
@@ -155,6 +165,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                             disabled={disabled}
                             onBlur={handleInputBlur}
                             onFocus={handleInputFocus}
+                            onChange={handleInputChange}
                             ref={ref}
                             type={type}
                             value={value}


### PR DESCRIPTION
# Опишите проблему

В **uncontrolled** инпуте лейбл наезжает на текст.

<img src="https://user-images.githubusercontent.com/9968618/80603350-f5829980-8a38-11ea-90f8-a536e46c2bc9.png" width="240"/>

# Шаги для воспроизведения
1. Перейти [сюда](https://alfa-laboratory.github.io/core-components/e2914b5691666e2a6e7de043ac65a1ec20ed3517/?path=/story/%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D1%8B-input--%D0%BF%D0%B5%D1%81%D0%BE%D1%87%D0%BD%D0%B8%D1%86%D0%B0)
2. Добавить инпуту лейбл
3. Ввести значение и убрать фокус

# Решение

Сейчас состояние `filled` определяется по `value`. В случае uncontrolled инпута - этого пропса нет.

Пришлось добавить обработчик ввода и стейт `filled`.
