### PR TITLE
fix(tag): fix disabled state

### DIFF
--- a/packages/tag/src/index.module.css
+++ b/packages/tag/src/index.module.css
@@ -57,12 +57,12 @@
 }
 
 .component {
-    &:active {
+    &:active:not(:disabled) {
         background-color: var(--tag-background-color-active);
         color: var(--tag-text-color);
     }
 
-    &:hover {
+    &:hover:not(:disabled) {
         border: var(--tag-border-width) var(--tag-border-style) var(--tag-border-color-hover);
     }
 


### PR DESCRIPTION
При задизейбленном состоянии при наведении и нажатии на тэг были некорректные стили.
Это воспроизводилось, если поместить тэг внутрь тэга `<label />`