### PR TITLE
fix(core-components-popover): change box-sizing to border-box

### DIFF
--- a/packages/popover/src/index.module.css
+++ b/packages/popover/src/index.module.css
@@ -12,6 +12,7 @@
     z-index: var(--popover-z-index);
     transition-property: opacity;
     transition-timing-function: ease;
+    box-sizing: border-box;
 }
 
 .arrow:after {


### PR DESCRIPTION
Изменил box-sizing на border-box, чтобы можно было поставить поповеру ширину родителя (width=100%) и бордер не торчал наружу.

![image](https://user-images.githubusercontent.com/9968618/82138479-6ee7fd80-9829-11ea-8092-04b3c54c0117.png)

![image](https://user-images.githubusercontent.com/9968618/82138460-4fe96b80-9829-11ea-84ef-34c0a08a6392.png)