### PR TITLE
feat(core-components-popover): can render without Transition

### DIFF
--- a/packages/popover/src/Component.stories.mdx
+++ b/packages/popover/src/Component.stories.mdx
@@ -62,6 +62,7 @@ import { Popover } from '@alfalab/core-components-popover';
                     transition={{ timeout: transitionTimeout }}
                     offset={[number('offset[0]', 0), number('offset[1]', 0)]}
                     withArrow={boolean('withArrow', false)}
+                    withTransition={boolean('withTransition', true)}
                 >
                     <div style={{ padding: '15px', width: '156px' }}>I am popover</div>
                 </Popover>

--- a/packages/popover/src/Component.test.tsx
+++ b/packages/popover/src/Component.test.tsx
@@ -84,6 +84,17 @@ describe('Styles tests', () => {
 });
 
 describe('Render tests', () => {
+    it('should render without Transition of withTransition is false', async () => {
+        const component = await renderPopover({
+            children: <div>I am popover</div>,
+            open: true,
+            anchorElement: document.body,
+            withTransition: false,
+        });
+
+        expect(component).toMatchSnapshot();
+    });
+
     it('should unmount without errors', async () => {
         const { unmount } = await renderPopover({
             children: <div>I am popover</div>,

--- a/packages/popover/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/popover/src/__snapshots__/Component.test.tsx.snap
@@ -75,3 +75,79 @@ Object {
   "unmount": [Function],
 }
 `;
+
+exports[`Render tests should render without Transition of withTransition is false 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div
+      alfa-portal-container=""
+    >
+      <div
+        class="component"
+        data-popper-escaped="true"
+        data-popper-placement="left"
+        data-popper-reference-hidden="true"
+        style="position: absolute; left: 0px; top: 0px; right: 0px; transform: translate(0px, 0px);"
+      >
+        <div>
+          I am popover
+        </div>
+      </div>
+    </div>
+    <div />
+  </body>,
+  "container": <div />,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
@@ -88,7 +88,7 @@ Object {
       alfa-portal-container=""
     >
       <div
-        class="component [object Object] popper mountOnEnter unmountOnExit in timeout children"
+        class="component [object Object] mountOnEnter unmountOnExit in timeout children popper"
         data-popper-escaped="true"
         data-popper-placement="left"
         data-popper-reference-hidden="true"


### PR DESCRIPTION
# Опишите проблему
В селекте понадобилось рендерить поповер без анимации(Transition).
Возможно, будут еще кейсы, когда нужен будет поповер, но без анимации или будет достаточно css.

# Решение
Добавил пропсу `withTransition`, которая позволяет отрендерить контент без Transition
