### PR TITLE
build: remove unused css-vars

### DIFF
--- a/bin/purgecss.js
+++ b/bin/purgecss.js
@@ -1,0 +1,28 @@
+const { PurgeCSS } = require('purgecss');
+const glob = require('glob');
+const fs = require('fs');
+const { promisify } = require('util');
+
+const writeFile = promisify(fs.writeFile);
+
+const matches = glob.sync('dist/**/*.css');
+
+matches.forEach(match => {
+    const purge = new PurgeCSS();
+
+    purge
+        .purge({
+            content: ['dist/**/*.js'],
+            css: [match],
+            variables: true,
+        })
+        .then(result => {
+            result.forEach(({ css, file }) => {
+                css = css.replace(/^:root {\n}\n/gm, '');
+                writeFile(file, css);
+            });
+        })
+        .catch(err => {
+            console.log(err);
+        });
+});

--- a/bin/purgecss.js
+++ b/bin/purgecss.js
@@ -5,7 +5,7 @@ const { promisify } = require('util');
 
 const writeFile = promisify(fs.writeFile);
 
-const matches = glob.sync('dist/**/*.css');
+const matches = glob.sync('dist/**/*.css', { ignore: 'dist/+(themes|vars)/**' });
 
 matches.forEach(match => {
     const purge = new PurgeCSS();

--- a/bin/purgecss.js
+++ b/bin/purgecss.js
@@ -18,6 +18,7 @@ matches.forEach(match => {
         })
         .then(result => {
             result.forEach(({ css, file }) => {
+                // удаляем пустые блоки :root
                 css = css.replace(/^:root {\n}\n/gm, '');
                 writeFile(file, css);
             });

--- a/bin/purgecss.sh
+++ b/bin/purgecss.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-# удаляем неиспользуемые css-переменные из сборки
+# удаляем неиспользуемые css-переменные из сборки в root-пакете
+node bin/purgecss.js
+
+# удаляем неиспользуемые css-переменные из сборки во всех подпакетах
 lerna exec --parallel \
     --ignore @alfalab/core-components-vars \
     --ignore @alfalab/core-components-themes \

--- a/bin/purgecss.sh
+++ b/bin/purgecss.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# удаляем неиспользуемые css-переменные из сборки
+lerna exec --parallel \
+    --ignore @alfalab/core-components-vars \
+    --ignore @alfalab/core-components-themes \
+    -- node ../../bin/purgecss.js

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "pub:patch": "RELEASE_TYPE=\"patch\" ./bin/publish.sh",
     "pub:minor": "RELEASE_TYPE=\"minor\" ./bin/publish.sh",
     "pub:major": "RELEASE_TYPE=\"major\" ./bin/publish.sh",
-    "release": "standard-version --no-verify --releaseCommitMessageFormat \"chore: release\""
+    "release": "standard-version --no-verify --releaseCommitMessageFormat \"chore: release\"",
+    "postbuild": "yarn purgecss",
+    "purgecss": "./bin/purgecss.sh"
   },
   "browserslist": {
     "production": [
@@ -113,6 +115,7 @@
     "postcss-mixins": "^6.2.3",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^1.19.1",
+    "purgecss": "^2.2.1",
     "raw-loader": "^4.0.1",
     "react-docgen-typescript-loader": "^3.6.0",
     "react-scripts": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,6 +6357,11 @@ commander@^4.0.1, commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
+  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
 commitizen@^4.0.3, commitizen@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/commitizen/-/commitizen-4.1.2.tgz#6095eb825fd3f0d3611df88e6803c69b23307e9a"
@@ -15315,6 +15320,15 @@ postcss@7.0.21:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+postcss@7.0.28:
+  version "7.0.28"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.28.tgz#d349ced7743475717ba91f6810efb58c51fb5dbb"
+  integrity sha512-YU6nVhyWIsVtlNlnAj1fHTsUKW5qxm3KEgzq2Jj6KTEFOTK8QWR12eIDvrlWhiSTK8WIBFTBhOJV4DY6dUuEbw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^6.0.1:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
@@ -15706,6 +15720,16 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+purgecss@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-2.2.1.tgz#aa3bdf23370f7539df6154f5e25df2da311cd018"
+  integrity sha512-wngRSLW1dpNr8kr3TL9nTJMyTFI5BiRiaUUEys5M1CA4zEHLF25fRHoshEeDqmhstaNTOddmpYM34zRrUtEGbQ==
+  dependencies:
+    commander "^5.0.0"
+    glob "^7.0.0"
+    postcss "7.0.28"
+    postcss-selector-parser "^6.0.2"
 
 q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Добавил удаление неиспользуемых css-переменных из итоговых css-файлов.
Используется пакет `purgecss`. Удаление происходит после сборки, триггером `postbuild`.
Использовать postcss-plugin или rollup-plugin не получилось, так как у нас css-модули, и на этапе сборки `purgecss` думает, что мы вообще не используем селекторы из нашего css, и выпиливает их) По-этому добавил постобработку скриптом.