### PR TITLE
build: add purgecss whitelist

### DIFF
--- a/bin/purgecss.js
+++ b/bin/purgecss.js
@@ -7,6 +7,13 @@ const writeFile = promisify(fs.writeFile);
 
 const matches = glob.sync('dist/**/*.css', { ignore: 'dist/+(themes|vars)/**' });
 
+/**
+ * Purgecss вырезает селекторы по атрибуту (например .component[data-popper-placement='left'] .arrow в поповере).
+ * https://github.com/FullHuman/purgecss/issues/303
+ * После того, как баг будет исправлен, можно будет это удалить, а пока добавляем сюда все такие селекторы.
+ */
+const whitelistPatternsChildren = [/component/];
+
 matches.forEach(match => {
     const purge = new PurgeCSS();
 
@@ -15,6 +22,7 @@ matches.forEach(match => {
             content: ['dist/**/*.js'],
             css: [match],
             variables: true,
+            whitelistPatternsChildren,
         })
         .then(result => {
             result.forEach(({ css, file }) => {


### PR DESCRIPTION
`Purgecss` вырезает селекторы по атрибуту
(например `.component[data-popper-placement='left'] .arrow` в поповере).

[Issue](https://github.com/FullHuman/purgecss/issues/303)

Решение:
Добавить в whitelist селекторы, которые вырезаются. Регулярки типа `\[.+\]` не работают, по-этому можно только добавить селекторы по классу.

После того, как баг будет исправлен, можно будет whitelist удалить , а пока добавляем туда. 
 