### PR TITLE
chore: actualize react & react-dom versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,8 +139,8 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.6",
-    "react": ">=16.12.0",
-    "react-dom": ">=16.12.0"
+    "react": ">=16.13.1",
+    "react-dom": ">=16.13.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -14,7 +14,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-loader": "^1.0.0"

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -13,7 +13,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -13,8 +13,8 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/icons-classic": "^1.7.0"

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -13,6 +13,6 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     }
 }

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -13,8 +13,8 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/icons-classic": "^1.7.0"

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -13,7 +13,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-form-control": "^1.0.0"

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -13,7 +13,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     }
 }

--- a/packages/masked-input/package.json
+++ b/packages/masked-input/package.json
@@ -13,7 +13,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-input": "^1.3.1",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -13,8 +13,8 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-portal": "^1.3.0",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -12,7 +12,7 @@
         "access": "public"
     },
     "peerDependencies": {
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     }
 }

--- a/packages/pure-input/package.json
+++ b/packages/pure-input/package.json
@@ -13,6 +13,6 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -13,8 +13,8 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-form-control": "^1.0.0",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -14,6 +14,6 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0"
+        "react": "^16.13.1"
     }
 }

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -13,7 +13,7 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -13,8 +13,8 @@
     },
     "peerDependencies": {
         "classnames": "^2.2.6",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0"
+        "react": "^16.13.1",
+        "react-dom": "^16.13.1"
     },
     "dependencies": {
         "@alfalab/core-components-popover": "^1.1.1",


### PR DESCRIPTION
Обновил `react` и `react-dom` до `16.13.1`, т.к. версия реакта различалась внутри проекта. 