### PR TITLE
fix(core-components-tooltip): pass target original classname

### DIFF
--- a/packages/tooltip/src/Component.test.tsx
+++ b/packages/tooltip/src/Component.test.tsx
@@ -295,3 +295,22 @@ describe('Hover event tests', () => {
         expect(content).toBeNull();
     });
 });
+
+describe('Child render tests', () => {
+    it('should pass child classname', async () => {
+        const childClassName = 'child-classname';
+        const testId = 'test-id';
+
+        const { getByTestId } = await renderTooltip({
+            children: (
+                <div className={childClassName} data-test-id={testId}>
+                    Hover me
+                </div>
+            ),
+            content: <div>I am tooltip</div>,
+            open: true,
+        });
+
+        expect(getByTestId(testId)).toHaveClass(childClassName);
+    });
+});

--- a/packages/tooltip/src/Component.tsx
+++ b/packages/tooltip/src/Component.tsx
@@ -216,9 +216,11 @@ export const Tooltip: FC<TooltipProps> = ({
         onTouchStart: handleTouchStart,
     };
 
-    const getTargetProps = (): HTMLAttributes<HTMLElement> => {
+    const getTargetProps = (
+        targetProps: HTMLAttributes<HTMLElement>,
+    ): HTMLAttributes<HTMLElement> => {
         const props = {
-            className: cn(styles.target),
+            className: cn(styles.target, targetProps.className),
         };
 
         switch (trigger) {
@@ -256,7 +258,7 @@ export const Tooltip: FC<TooltipProps> = ({
     };
 
     const renderTarget = () => {
-        const props = getTargetProps();
+        const props = getTargetProps(children.props);
 
         return cloneElement(children, props);
     };


### PR DESCRIPTION
Пофиксил потерявшийся className у дочернего элемента в тултипе