### PR TITLE
feat(core-components-form-control): change errors logic

### DIFF
--- a/packages/form-control/src/Component.stories.mdx
+++ b/packages/form-control/src/Component.stories.mdx
@@ -30,8 +30,8 @@ import { FormControl } from '@alfalab/core-components-form-control';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        hideErrorIcon={boolean('hideErrorIcon', false)}
-        rightAddons={boolean('rightAddons', false) && (!text('error') || boolean('hideErrorIcon')) && <Icon />}
+        hasErrorIcon={boolean('hasErrorIcon', true)}
+        rightAddons={boolean('rightAddons', false) && !(text('error') && boolean('hasErrorIcon')) && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/form-control/src/Component.stories.mdx
+++ b/packages/form-control/src/Component.stories.mdx
@@ -30,7 +30,8 @@ import { FormControl } from '@alfalab/core-components-form-control';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        rightAddons={boolean('rightAddons', false) && !text('error', '') && <Icon />}
+        hideErrorIcon={boolean('hideErrorIcon', false)}
+        rightAddons={boolean('rightAddons', false) && (!text('error') || boolean('hideErrorIcon')) && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/form-control/src/Component.stories.mdx
+++ b/packages/form-control/src/Component.stories.mdx
@@ -30,8 +30,7 @@ import { FormControl } from '@alfalab/core-components-form-control';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        hasErrorIcon={boolean('hasErrorIcon', true)}
-        rightAddons={boolean('rightAddons', false) && !(text('error') && boolean('hasErrorIcon')) && <Icon />}
+        rightAddons={boolean('rightAddons', false) && !text('error') && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -36,11 +36,6 @@ export type FormControlProps = HTMLAttributes<HTMLDivElement> & {
     error?: string | boolean;
 
     /**
-     * Показывать иконку ошибки
-     */
-    hasErrorIcon?: boolean;
-
-    /**
      * Текст подсказки
      */
     hint?: string;
@@ -95,7 +90,6 @@ export const FormControl = ({
     focused,
     filled,
     error,
-    hasErrorIcon = true,
     hint,
     label,
     leftAddons,
@@ -105,18 +99,16 @@ export const FormControl = ({
     dataTestId,
     ...restProps
 }: FormControlProps) => {
-    const rightAddonsRenderer = useCallback(() => {
-        const showIcon = error && hasErrorIcon;
-
-        return (
-            (showIcon || rightAddons) && (
+    const rightAddonsRenderer = useCallback(
+        () =>
+            (error || rightAddons) && (
                 <div className={cn(styles.addons)}>
-                    {showIcon && <ErrorIcon />}
+                    {error && <ErrorIcon />}
                     {rightAddons}
                 </div>
-            )
-        );
-    }, [error, hasErrorIcon, rightAddons]);
+            ),
+        [error, rightAddons],
+    );
 
     const leftAddonsRenderer = useCallback(
         () => leftAddons && <div className={styles.addons}>{leftAddons}</div>,

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -36,9 +36,9 @@ export type FormControlProps = HTMLAttributes<HTMLDivElement> & {
     error?: string | boolean;
 
     /**
-     * Скрыть иконку ошибки
+     * Показывать иконку ошибки
      */
-    hideErrorIcon?: boolean;
+    hasErrorIcon?: boolean;
 
     /**
      * Текст подсказки
@@ -95,7 +95,7 @@ export const FormControl = ({
     focused,
     filled,
     error,
-    hideErrorIcon = false,
+    hasErrorIcon = true,
     hint,
     label,
     leftAddons,
@@ -106,7 +106,7 @@ export const FormControl = ({
     ...restProps
 }: FormControlProps) => {
     const rightAddonsRenderer = useCallback(() => {
-        const showIcon = error && !hideErrorIcon;
+        const showIcon = error && hasErrorIcon;
 
         return (
             (showIcon || rightAddons) && (
@@ -116,7 +116,7 @@ export const FormControl = ({
                 </div>
             )
         );
-    }, [error, hideErrorIcon, rightAddons]);
+    }, [error, hasErrorIcon, rightAddons]);
 
     const leftAddonsRenderer = useCallback(
         () => leftAddons && <div className={styles.addons}>{leftAddons}</div>,

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -31,9 +31,14 @@ export type FormControlProps = HTMLAttributes<HTMLDivElement> & {
     focused?: boolean;
 
     /**
-     * Текст ошибки
+     * Отображение ошибки
      */
-    error?: string;
+    error?: string | boolean;
+
+    /**
+     * Скрыть иконку ошибки
+     */
+    hideErrorIcon?: boolean;
 
     /**
      * Текст подсказки
@@ -90,6 +95,7 @@ export const FormControl = ({
     focused,
     filled,
     error,
+    hideErrorIcon = false,
     hint,
     label,
     leftAddons,
@@ -99,21 +105,25 @@ export const FormControl = ({
     dataTestId,
     ...restProps
 }: FormControlProps) => {
-    const rightAddonsRenderer = useCallback(
-        () =>
-            (error || rightAddons) && (
+    const rightAddonsRenderer = useCallback(() => {
+        const showIcon = error && !hideErrorIcon;
+
+        return (
+            (showIcon || rightAddons) && (
                 <div className={cn(styles.addons)}>
-                    {error && <ErrorIcon />}
+                    {showIcon && <ErrorIcon />}
                     {rightAddons}
                 </div>
-            ),
-        [error, rightAddons],
-    );
+            )
+        );
+    }, [error, hideErrorIcon, rightAddons]);
 
     const leftAddonsRenderer = useCallback(
         () => leftAddons && <div className={styles.addons}>{leftAddons}</div>,
         [leftAddons],
     );
+
+    const errorMessage = typeof error === 'string' ? error : '';
 
     return (
         <div
@@ -151,7 +161,9 @@ export const FormControl = ({
                 {rightAddonsRenderer()}
             </div>
 
-            {(error || hint) && <span className={styles.sub}>{error || hint}</span>}
+            {errorMessage && <span className={cn(styles.sub, styles.error)}>{errorMessage}</span>}
+
+            {hint && !errorMessage && <span className={styles.sub}>{hint}</span>}
 
             {bottomAddons}
         </div>

--- a/packages/form-control/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/form-control/src/__snapshots__/Component.test.tsx.snap
@@ -19,6 +19,7 @@ Object {
             />
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -37,6 +38,7 @@ Object {
           />
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],
@@ -132,7 +134,7 @@ Object {
           </div>
         </div>
         <span
-          class="sub"
+          class="sub error"
         >
           error
         </span>
@@ -174,7 +176,7 @@ Object {
         </div>
       </div>
       <span
-        class="sub"
+        class="sub error"
       >
         error
       </span>
@@ -253,6 +255,7 @@ Object {
             />
           </div>
         </div>
+        
         <div>
           Bottom addons
         </div>
@@ -274,6 +277,7 @@ Object {
           />
         </div>
       </div>
+      
       <div>
         Bottom addons
       </div>
@@ -372,7 +376,7 @@ Object {
           </div>
         </div>
         <span
-          class="sub"
+          class="sub error"
         >
           This is error
         </span>
@@ -414,7 +418,7 @@ Object {
         </div>
       </div>
       <span
-        class="sub"
+        class="sub error"
       >
         This is error
       </span>
@@ -493,6 +497,7 @@ Object {
             />
           </div>
         </div>
+        
         <span
           class="sub"
         >
@@ -516,6 +521,7 @@ Object {
           />
         </div>
       </div>
+      
       <span
         class="sub"
       >
@@ -607,6 +613,7 @@ Object {
             />
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -636,6 +643,7 @@ Object {
           />
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],
@@ -718,6 +726,7 @@ Object {
             />
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -743,6 +752,7 @@ Object {
           />
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],
@@ -825,6 +835,7 @@ Object {
             </div>
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -850,6 +861,7 @@ Object {
           </div>
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],

--- a/packages/form-control/src/index.module.css
+++ b/packages/form-control/src/index.module.css
@@ -205,7 +205,7 @@
 
 /* ERROR STATE */
 
-.hasError .sub {
+.error {
     color: var(--form-control-error-color);
 }
 

--- a/packages/input/src/Component.stories.mdx
+++ b/packages/input/src/Component.stories.mdx
@@ -34,7 +34,8 @@ import { Input } from '@alfalab/core-components-input';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        rightAddons={boolean('rightAddons', false) && !text('error', '') && <Icon />}
+        hideErrorIcon={boolean('hideErrorIcon', false)}
+        rightAddons={boolean('rightAddons', false) && (!text('error') || boolean('hideErrorIcon')) && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/input/src/Component.stories.mdx
+++ b/packages/input/src/Component.stories.mdx
@@ -34,8 +34,7 @@ import { Input } from '@alfalab/core-components-input';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        hasErrorIcon={boolean('hasErrorIcon', false)}
-        rightAddons={boolean('rightAddons', false) && !(text('error') && boolean('hasErrorIcon')) && <Icon />}
+        rightAddons={boolean('rightAddons', false) && !text('error') && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/input/src/Component.stories.mdx
+++ b/packages/input/src/Component.stories.mdx
@@ -34,8 +34,8 @@ import { Input } from '@alfalab/core-components-input';
         label={text('label', '')}
         hint={text('hint', '')}
         error={text('error', '')}
-        hideErrorIcon={boolean('hideErrorIcon', false)}
-        rightAddons={boolean('rightAddons', false) && (!text('error') || boolean('hideErrorIcon')) && <Icon />}
+        hasErrorIcon={boolean('hasErrorIcon', false)}
+        rightAddons={boolean('rightAddons', false) && !(text('error') && boolean('hasErrorIcon')) && <Icon />}
         leftAddons={boolean('leftAddons', false) && <Icon />}
         bottomAddons={boolean('bottomAddons', false) && <span>bottom text</span>}
     />

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -16,9 +16,14 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 't
     size?: 's' | 'm' | 'l';
 
     /**
-     * Текст ошибки
+     * Отображение ошибки
      */
-    error?: string;
+    error?: string | boolean;
+
+    /**
+     * Скрыть иконку ошибки
+     */
+    hideErrorIcon?: boolean;
 
     /**
      * Текст подсказки
@@ -77,6 +82,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             dataTestId,
             disabled,
             error,
+            hideErrorIcon,
             hint,
             inputClassName,
             label,
@@ -135,6 +141,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 filled={filled || focused || !!value}
                 focused={focused}
                 error={error}
+                hideErrorIcon={hideErrorIcon}
                 label={label}
                 hint={hint}
                 leftAddons={leftAddons}

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -21,11 +21,6 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 't
     error?: string | boolean;
 
     /**
-     * Показывать иконку ошибки
-     */
-    hasErrorIcon?: boolean;
-
-    /**
      * Текст подсказки
      */
     hint?: string;
@@ -82,7 +77,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             dataTestId,
             disabled,
             error,
-            hasErrorIcon,
             hint,
             inputClassName,
             label,
@@ -141,7 +135,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 filled={filled || focused || !!value}
                 focused={focused}
                 error={error}
-                hasErrorIcon={hasErrorIcon}
                 label={label}
                 hint={hint}
                 leftAddons={leftAddons}

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -21,9 +21,9 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 't
     error?: string | boolean;
 
     /**
-     * Скрыть иконку ошибки
+     * Показывать иконку ошибки
      */
-    hideErrorIcon?: boolean;
+    hasErrorIcon?: boolean;
 
     /**
      * Текст подсказки
@@ -82,7 +82,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             dataTestId,
             disabled,
             error,
-            hideErrorIcon,
+            hasErrorIcon,
             hint,
             inputClassName,
             label,
@@ -141,7 +141,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 filled={filled || focused || !!value}
                 focused={focused}
                 error={error}
-                hideErrorIcon={hideErrorIcon}
+                hasErrorIcon={hasErrorIcon}
                 label={label}
                 hint={hint}
                 leftAddons={leftAddons}

--- a/packages/input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input/src/__snapshots__/Component.test.tsx.snap
@@ -25,6 +25,7 @@ Object {
             </div>
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -49,6 +50,7 @@ Object {
           </div>
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],

--- a/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
@@ -25,6 +25,7 @@ Object {
             </div>
           </div>
         </div>
+        
       </div>
     </div>
   </body>,
@@ -49,6 +50,7 @@ Object {
           </div>
         </div>
       </div>
+      
     </div>
   </div>,
   "debug": [Function],

--- a/packages/select/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/select/src/__snapshots__/Component.test.tsx.snap
@@ -60,6 +60,7 @@ Object {
                 </svg>
               </div>
             </div>
+            
           </div>
         </div>
         <div
@@ -128,6 +129,7 @@ Object {
               </svg>
             </div>
           </div>
+          
         </div>
       </div>
       <div


### PR DESCRIPTION
# Опишите проблему
 
- Нет возможности рендерить контрол в состоянии ошибки без текста
- Нет возможности скрыть иконку ошибки

https://github.com/alfa-laboratory/core-components/issues/148

# Решение

- Изменил тип error на `string | boolean`
- ~Добавил пропс `hasErrorIcon`~
- Если `error=true`, то hint отрисовывается. Если `error=string`, то вместо хинта рендерится ошибка

