### PR TITLE
Style/checkbox group

### DIFF
--- a/packages/checkbox-group/src/Component.tsx
+++ b/packages/checkbox-group/src/Component.tsx
@@ -127,6 +127,7 @@ export const CheckboxGroup: FC<CheckboxGroupProps> = ({
         <div
             className={cn(
                 styles.component,
+                styles[type],
                 styles[direction],
                 { [styles.error]: error },
                 className,

--- a/packages/checkbox-group/src/index.module.css
+++ b/packages/checkbox-group/src/index.module.css
@@ -33,13 +33,17 @@
     margin-bottom: var(--gap-xs-neg);
 }
 
+.tag.horizontal .checkboxList {
+    margin-right: var(--gap-xs-neg);
+}
+
 .horizontal .checkbox {
     margin-right: var(--gap-xl);
     margin-bottom: var(--gap-xs);
+}
 
-    &:last-child {
-        margin-right: 0;
-    }
+.horizontal .tag-label {
+    margin-right: var(--gap-xs);
 }
 
 .label {

--- a/packages/checkbox-group/src/index.module.css
+++ b/packages/checkbox-group/src/index.module.css
@@ -29,6 +29,8 @@
 
 .horizontal .checkboxList {
     flex-wrap: wrap;
+    margin-right: var(--gap-xl-neg);
+    margin-bottom: var(--gap-xs-neg);
 }
 
 .horizontal .checkbox {


### PR DESCRIPTION
# Опишите проблему
1) компонент CheckboxGroup создает внешний отступ вниз при горизонтальном отображении
2) при горизонтальном отображении обнуление отступа вправо у last-child не отрабатывает в случае, если несколько рядов
3) если в компоненте CheckboxGroup значение type - 'tag', то отступ при горизонтальном отображении не соответствует макетам

# Шаги для воспроизведения
1. Перейти на страницу с CheckboxGroup https://alfa-laboratory.github.io/core-components/master/?path=/story/%D0%BA%D0%BE%D0%BC%D0%BF%D0%BE%D0%BD%D0%B5%D0%BD%D1%82%D1%8B-checkboxgroup--%D0%BF%D0%B5%D1%81%D0%BE%D1%87%D0%BD%D0%B8%D1%86%D0%B0