### PR TITLE
fix(checkbox-group): fix css classnames

### DIFF
--- a/packages/checkbox-group/src/index.module.css
+++ b/packages/checkbox-group/src/index.module.css
@@ -42,7 +42,7 @@
     margin-bottom: var(--gap-xs);
 }
 
-.horizontal .tag-label {
+.horizontal .tagLabel {
     margin-right: var(--gap-xs);
 }
 
@@ -52,7 +52,7 @@
     color: var(--color-dark-indigo-60-flat);
 }
 
-.error-message {
+.errorMessage {
     @mixin system_14-18_regular;
     margin-top: var(--gap-m);
     color: var(--color-red-brand-85-flat);
@@ -66,6 +66,6 @@
     opacity: 0;
 }
 
-.tag-label {
+.tagLabel {
     position: relative;
 }


### PR DESCRIPTION
# Опишите проблему
При импорте компонента CheckboxGroup не подцепляются стили, написанные в kebab-case