### PR TITLE
build: pass css classnames as is

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -112,7 +112,6 @@ module.exports = ({ config }) => ({
                             modules: {
                                 localIdentName: '[local]_[hash:base64:5]',
                             },
-                            localsConvention: 'dashes',
                             importLoaders: 1,
                             sourceMap: true,
                         },


### PR DESCRIPTION
Убрал трансформацию классов, теперь они попадают в объект `styles` как есть. Больше не будет путаницы с `kebabcase` и `camelcase`