### PR TITLE
build: add babel-preset-env to storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -25,7 +25,8 @@ const getBabelRules = ({ mode, withRDTL }) => {
                                 allExtensions: true,
                             },
                         ],
-                    ],
+                        '@babel/preset-env',
+                    ]
                 },
             },
         ],
@@ -80,6 +81,9 @@ module.exports = ({ config }) => ({
                         // may or may not need this line depending on your app's setup
                         options: {
                             plugins: ['@babel/plugin-transform-react-jsx'],
+                            presets: [
+                                '@babel/preset-env',
+                            ]
                         },
                     },
                     {
@@ -100,6 +104,20 @@ module.exports = ({ config }) => ({
                 mode: config.mode,
                 withRDTL: process.env.RDTL !== 'off',
             }),
+            {
+                test: /\.js$/,
+                use: [
+                    {
+                        loader: 'babel-loader',
+                        options: {
+                            presets: [
+                                '@babel/preset-env',
+                            ]
+                        },
+                    },
+                ],
+                exclude: [/node_modules\/core-js/]
+            },
             {
                 test: /\.css$/,
                 use: [


### PR DESCRIPTION
Добавил `preset-env` в babel, чтобы сторибук заработал в ie11