### PR TITLE
feat(core-components-popover): add classname for tooltip popover

### DIFF
--- a/packages/tooltip/src/Component.tsx
+++ b/packages/tooltip/src/Component.tsx
@@ -90,6 +90,11 @@ export type TooltipProps = {
      * Дополнительный класс для контента
      */
     contentClassName?: string;
+
+    /**
+     * Дополнительный класс для поповера
+     */
+    popoverClassName?: string;
 };
 
 export const Tooltip: FC<TooltipProps> = ({
@@ -107,6 +112,7 @@ export const Tooltip: FC<TooltipProps> = ({
     position,
     contentClassName,
     arrowClassName,
+    popoverClassName,
 }) => {
     const [visible, setVisible] = useState(!!forcedOpen);
     const [target, setTarget] = useState<RefElement>(null);
@@ -287,7 +293,7 @@ export const Tooltip: FC<TooltipProps> = ({
                     open={show}
                     getPortalContainer={getPortalContainer}
                     arrowClassName={arrowClassName}
-                    popperClassName={styles.popper}
+                    popperClassName={cn(styles.popper, popoverClassName)}
                     offset={offset}
                     withArrow={true}
                     position={position}


### PR DESCRIPTION
Для позиционирования тултип использует компонент `Popover`. У этого компонента есть
css-переменная `--popover-z-index`. По-дефолту она равна 1. `Popover` также используется в компоненте `Select`.

Можно добавить переопределение этой переменной в тему.

На всякий случай добавил пропсу `popoverClassName` в тултип. По этому класснейму можно будет накинуть
любой `z-index`.