### PR TITLE
fix(tag): fix bug vertical align ie11

### DIFF
--- a/packages/tag/src/index.module.css
+++ b/packages/tag/src/index.module.css
@@ -84,7 +84,7 @@
 }
 
 .xs {
-    min-height: 32px;
+    height: 32px;
     padding: 4px 16px;
     border-radius: 32px;
     font-size: 14px;
@@ -93,7 +93,7 @@
 }
 
 .s {
-    min-height: 48px;
+    height: 48px;
     padding: 4px 16px;
     border-radius: 48px;
     font-size: 16px;
@@ -102,7 +102,7 @@
 }
 
 .m {
-    min-height: 56px;
+    height: 56px;
     padding: 4px 24px;
     border-radius: 56px;
     font-size: 16px;
@@ -111,7 +111,7 @@
 }
 
 .l {
-    min-height: 68px;
+    height: 68px;
     padding: 4px 32px;
     border-radius: 68px;
     font-size: 18px;


### PR DESCRIPTION
# Опишите проблему
В ie11 не работает вертикальное выравнивание с флексом если не задать фиксированную высоту. В ишью есть непонятные мне воркэраунды, но я просто поставил фиксированную высоту как в принципе и должно было быть, вроде комопнент не должен расти в высоту 

сам сабж https://github.com/philipwalton/flexbugs/issues/231

# Шаги для воспроизведения
1. Потестировать в ie11
2. Увидеть контент компонента "тег" не по центру

# Ожидаемое поведение
Контент по центру
