### PR TITLE
feat(core-components-hooks): add useKeyboardOnlyFocus

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@alfalab/core-components-hooks",
+    "version": "1.0.0",
+    "description": "",
+    "keywords": [],
+    "license": "ISC",
+    "main": "dist/index.js",
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "peerDependencies": {
+        "classnames": "^2.2.6",
+        "react": "^16.9.0"
+    }
+}

--- a/packages/hooks/src/index.ts
+++ b/packages/hooks/src/index.ts
@@ -1,0 +1,1 @@
+export * from './useKeyboardOnlyFocus';

--- a/packages/hooks/src/useKeyboardOnlyFocus.css
+++ b/packages/hooks/src/useKeyboardOnlyFocus.css
@@ -1,0 +1,25 @@
+@import '../../themes/src/default.css';
+
+:root {
+    --keyboard-focus-outline: 2px solid var(--focus-color);
+    --keyboard-focus-outline-offset: 2px;
+}
+
+.wrapper {
+    position: relative;
+    outline: none;
+}
+
+.focus {
+    outline: none;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wrapper:focus .focus {
+    outline: var(--keyboard-focus-outline);
+    outline-offset: var(--keyboard-focus-outline-offset);
+}

--- a/packages/hooks/src/useKeyboardOnlyFocus.stories.mdx
+++ b/packages/hooks/src/useKeyboardOnlyFocus.stories.mdx
@@ -9,8 +9,6 @@ import { useKeyboardOnlyFocus } from './useKeyboardOnlyFocus';
 
 Хук для настройки Keyboard-Only фокуса — обводка будет видна только в случае выбора элемента с клавиатуры.
 
-В отличии от `:focus-visible`, позволяет настроить такой фокус для `<input type={text|email|password|...}>` или `<textarea>`
-
 ---
 
 ### Пример
@@ -19,10 +17,16 @@ import { useKeyboardOnlyFocus } from './useKeyboardOnlyFocus';
     {React.createElement(() => {
         const { wrapperProps, focusProps } = useKeyboardOnlyFocus();
         return (
-            <a href='#' {...wrapperProps}>
-                <span {...focusProps} />
-                focus me
-            </a>
+            <React.Fragment>
+                <button style={{ padding: '5px', borderColor: 'red' }}>
+                    Стандартный фокус
+                </button>
+                <div style={{ marginBottom: '10px' }} />
+                <button style={{ padding: '5px', borderColor: 'red' }} {...wrapperProps}>
+                    <span {...focusProps} />
+                    Keyboard only фокус
+                </button>
+            </React.Fragment>
         );
     })}
 </Preview>

--- a/packages/hooks/src/useKeyboardOnlyFocus.stories.mdx
+++ b/packages/hooks/src/useKeyboardOnlyFocus.stories.mdx
@@ -1,0 +1,28 @@
+import { Meta, Story, Props, Title, Preview } from '@storybook/addon-docs/blocks';
+import { text, select, boolean } from '@storybook/addon-knobs';
+import { Design } from 'storybook/blocks/design';
+import { useKeyboardOnlyFocus } from './useKeyboardOnlyFocus';
+
+<Meta title='Хуки|useKeyboardOnlyFocus' />
+
+## useKeyboardOnlyFocus
+
+Хук для настройки Keyboard-Only фокуса — обводка будет видна только в случае выбора элемента с клавиатуры.
+
+В отличии от `:focus-visible`, позволяет настроить такой фокус для `<input type={text|email|password|...}>` или `<textarea>`
+
+---
+
+### Пример
+
+<Preview isExpanded={true}>
+    {React.createElement(() => {
+        const { wrapperProps, focusProps } = useKeyboardOnlyFocus();
+        return (
+            <a href='#' {...wrapperProps}>
+                <span {...focusProps} />
+                focus me
+            </a>
+        );
+    })}
+</Preview>

--- a/packages/hooks/src/useKeyboardOnlyFocus.tsx
+++ b/packages/hooks/src/useKeyboardOnlyFocus.tsx
@@ -1,0 +1,15 @@
+import styles from './useKeyboardOnlyFocus.css';
+
+export function useKeyboardOnlyFocus() {
+    return {
+        wrapperProps: {
+            className: styles.wrapper,
+            tabIndex: 0,
+        },
+
+        focusProps: {
+            className: styles.focus,
+            tabIndex: -1,
+        },
+    };
+}

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "include": ["src", "../../typings"],
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDirs": ["src"],
+        "baseUrl": "."
+    }
+}


### PR DESCRIPTION
Добавил хук для настройки Keyboard-Only фокуса — обводка будет видна только в случае выбора элемента с клавиатуры.

По [дизайн-системе](https://github.com/WICG/focus-visible) все интерактивные элементы должны иметь определенную обводку при фокусе, но только при переключении с клавиатуры. При клике мышки обводки быть не должно. Данный хук позволяет добиться такого поведения. Есть еще https://github.com/WICG/focus-visible, но это более сложное решение. 
