### PR TITLE
feat(tag): remove pointer-events none style

### DIFF
--- a/packages/tag/src/index.module.css
+++ b/packages/tag/src/index.module.css
@@ -67,10 +67,6 @@
     &:hover:not(:disabled) {
         border: var(--tag-border-width) var(--tag-border-style) var(--tag-border-color-hover);
     }
-
-    &:disabled {
-        pointer-events: none;
-    }
 }
 
 .checked {


### PR DESCRIPTION
# Опишите проблему
События мыши не срабатывают на задизейбленом теге.
Например есть кейс, что нужно пользователю показать почему задизейблена кнопка
![image](https://user-images.githubusercontent.com/2098777/89995721-89980a00-dc92-11ea-8fb7-c8a0d5115a55.png)


# Шаги для воспроизведения
https://codesandbox.io/s/quirky-cerf-l6j32?file=/src/App.js

# Ожидаемое поведение
События мыши срабатывают на задизейбленом теге

# Чек лист
- [x] Тесты
- [x] Документация