### PR TITLE
fix(core-components-button): fix loader position

### DIFF
--- a/packages/button/src/index.module.css
+++ b/packages/button/src/index.module.css
@@ -72,10 +72,6 @@
 
 .loader {
     position: absolute;
-    left: 0;
-    right: 0;
-    margin-left: auto;
-    margin-right: auto;
 }
 
 /* Size */

--- a/packages/button/src/index.module.css
+++ b/packages/button/src/index.module.css
@@ -37,6 +37,7 @@
 }
 
 .component {
+    position: relative;
     display: inline-flex;
     flex-direction: row;
     flex-wrap: nowrap;
@@ -71,6 +72,10 @@
 
 .loader {
     position: absolute;
+    left: 0;
+    right: 0;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* Size */

--- a/packages/button/src/index.module.css
+++ b/packages/button/src/index.module.css
@@ -279,6 +279,6 @@
 /* Block */
 
 .block {
-    display: block;
+    display: flex;
     width: 100%;
 }


### PR DESCRIPTION
- При `block=true` - лоудер не по центру.
![image](https://user-images.githubusercontent.com/9968618/90755620-fbe89a00-e2e3-11ea-8e2a-e0b13b5fb04f.png)

- При `block=true` и пустом контенте - лоудер не по центру.
![image](https://user-images.githubusercontent.com/9968618/90755744-276b8480-e2e4-11ea-8d1d-0ac060957f4c.png)



