### PR TITLE
fix: fix import example

### DIFF
--- a/packages/typography/src/Component.stories.mdx
+++ b/packages/typography/src/Component.stories.mdx
@@ -18,7 +18,7 @@ import { colors } from './colors';
 </Status>
 
 ```tsx
-import { Typography } from '@alfalab/core-components-tooltip/typography';
+import { Typography } from '@alfalab/core-components-typography';
 ```
 
 <Design>


### PR DESCRIPTION
# Опишите проблему
Ошика в примере импорта

# Дополнительная информация
Какой из импортов верный:

1) `import { Typography } from '@alfalab/core-components-typography';`
2) `import { Typography } from '@alfalab/core-components/typography';`