### PR TITLE
refactor: allow only string as value, add payload

### DIFF
--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -1,10 +1,18 @@
-import React, { useState, InputHTMLAttributes, useCallback } from 'react';
+import React, { useState, InputHTMLAttributes, useCallback, ChangeEvent } from 'react';
 import cn from 'classnames';
 import { FormControl } from '@alfalab/core-components-form-control';
 
 import styles from './index.module.css';
 
-export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'type'> & {
+export type InputProps = Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'type' | 'value' | 'onChange'
+> & {
+    /**
+     * Значение поля ввода
+     */
+    value?: string;
+
     /**
      * Растягивает компонент на ширину контейнера
      */
@@ -64,6 +72,11 @@ export type InputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 't
      * Дополнительный класс инпута
      */
     inputClassName?: string;
+
+    /**
+     * Обработчик поля ввода
+     */
+    onChange?: (event: ChangeEvent<HTMLInputElement>, payload: { value: string }) => void;
 
     /**
      * Идентификатор для систем автоматизированного тестирования
@@ -126,7 +139,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 setFilled(e.target.value !== '');
 
                 if (onChange) {
-                    onChange(e);
+                    onChange(e, { value: e.target.value });
                 }
             },
             [onChange],

--- a/packages/masked-input/src/Component.tsx
+++ b/packages/masked-input/src/Component.tsx
@@ -1,13 +1,8 @@
-import React, { useEffect, useRef, useCallback, useImperativeHandle } from 'react';
+import React, { useEffect, useRef, useCallback, useImperativeHandle, ChangeEvent } from 'react';
 import { createTextMaskInputElement, TextMaskConfig, TextMaskInputElement } from 'text-mask-core';
 import { Input, InputProps } from '@alfalab/core-components-input';
 
-export type MaskedInputProps = Omit<InputProps, 'value'> & {
-    /**
-     * Значение поля
-     */
-    value?: string;
-
+export type MaskedInputProps = InputProps & {
     /**
      * Маска для поля ввода
      * https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#mask-array
@@ -32,9 +27,9 @@ export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
         useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
         const handleInputChange = useCallback(
-            event => {
+            (event: ChangeEvent<HTMLInputElement>) => {
                 if (textMask.current) textMask.current.update();
-                if (onChange) onChange(event);
+                if (onChange) onChange(event, { value: event.target.value });
             },
             [onChange, textMask],
         );


### PR DESCRIPTION
- Инпуты для унификации теперь принимают только строки. Для ввода чисел есть `AmountInput`. `string[]` - это вообще дичь.
- В onChange теперь передается `payload: { value: string }`