### PR TITLE
fix(core-components-tabs): recalc line styles on render

### DIFF
--- a/packages/tabs/src/components/primary-tablist/Component.tsx
+++ b/packages/tabs/src/components/primary-tablist/Component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import cn from 'classnames';
 import { useTabs } from '../../useTabs';
 import { ScrollableContainer } from '../scrollable-container';
@@ -13,21 +13,20 @@ export const PrimaryTabList = ({
     onChange,
     dataTestId,
 }: TabListProps & Styles) => {
+    const lineRef = useRef<HTMLDivElement>(null);
+
     const { selectedTab, focusedTab, getTabListItemProps } = useTabs({
         titles,
         selectedId,
         onChange,
     });
-    const [lineStyles, setLineStyles] = useState<{ width?: number; transform?: string }>();
 
     useEffect(() => {
-        if (selectedTab) {
-            setLineStyles({
-                width: selectedTab.offsetWidth,
-                transform: `translateX(${selectedTab.offsetLeft}px)`,
-            });
+        if (selectedTab && lineRef.current) {
+            lineRef.current.style.width = `${selectedTab.offsetWidth}px`;
+            lineRef.current.style.transform = `translateX(${selectedTab.offsetLeft}px)`;
         }
-    }, [selectedTab]);
+    });
 
     const renderContent = () => (
         <React.Fragment>
@@ -46,7 +45,7 @@ export const PrimaryTabList = ({
                 </button>
             ))}
 
-            <div className={styles.line} style={lineStyles} />
+            <div className={styles.line} ref={lineRef} />
         </React.Fragment>
     );
 

--- a/packages/tabs/src/components/primary-tablist/index.module.css
+++ b/packages/tabs/src/components/primary-tablist/index.module.css
@@ -61,7 +61,7 @@
     bottom: 0;
     left: 0;
     background-color: var(--primary-tablist-line-color);
-    transition: transform 0.2s ease;
+    transition: transform 0.2s ease, width 0.2s ease;
 }
 
 .scrollable .line {


### PR DESCRIPTION
В newclick-host-ui при первом рендере ширина табов равна нулю и т.к. при ререндере вкладка не изменилась, то эффект с пересчетом стилей не запускается. Выглядит все так:

![image](https://user-images.githubusercontent.com/9968618/91530585-09b9a300-e914-11ea-975d-4de504052910.png)

Теперь стили обновляются при каждом рендере, это поможет избежать других потенциальных проблем. 
