### PR TITLE
chore: edit minor font-weight

### DIFF
--- a/packages/amount/src/index.module.css
+++ b/packages/amount/src/index.module.css
@@ -2,7 +2,7 @@
 
 :root {
     --amount-major-part-font-weight: bold;
-    --amount-minor-part-font-weight: normal;
+    --amount-minor-part-font-weight: bold;
 }
 
 .component {


### PR DESCRIPTION
# Опишите проблему
Когда делали компонент amount минорные единицы были тонкие, сейчас они стали жирные, как и основные единицы.
