### PR TITLE
feat(core-components-input): add clear button, some improvements

### DIFF
--- a/bin/purgecss.js
+++ b/bin/purgecss.js
@@ -12,7 +12,7 @@ const matches = glob.sync('dist/**/*.css', { ignore: 'dist/+(themes|vars|bank-ca
  * https://github.com/FullHuman/purgecss/issues/303
  * После того, как баг будет исправлен, можно будет это удалить, а пока добавляем сюда все такие селекторы.
  */
-const whitelistPatternsChildren = [/component/, /filled/, /focused/];
+const whitelistPatternsChildren = [/component/, /filled/, /focused/, /svg/];
 
 matches.forEach(match => {
     const purge = new PurgeCSS();

--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -63,6 +63,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     onChange,
     onBlur,
     onFocus,
+    onClear,
     ...restProps
 }: AmountInputProps) => {
     const [focused, setFocused] = useState(false);
@@ -151,25 +152,36 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     };
 
     const handleInputFocus = useCallback(
-        (e: React.FocusEvent<HTMLInputElement>) => {
+        (event: React.FocusEvent<HTMLInputElement>) => {
             setFocused(true);
 
             if (onFocus) {
-                onFocus(e);
+                onFocus(event);
             }
         },
         [onFocus],
     );
 
     const handleInputBlur = useCallback(
-        (e: React.FocusEvent<HTMLInputElement>) => {
+        (event: React.FocusEvent<HTMLInputElement>) => {
             setFocused(false);
 
             if (onBlur) {
-                onBlur(e);
+                onBlur(event);
             }
         },
         [onBlur],
+    );
+
+    const handleClear = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement>) => {
+            setInputValue('');
+
+            if (onClear) {
+                onClear(event);
+            }
+        },
+        [onClear],
     );
 
     const [majorPart, minorPart] = inputValue.split(',');
@@ -208,6 +220,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
                 onChange={handleChange}
                 onFocus={handleInputFocus}
                 onBlur={handleInputBlur}
+                onClear={handleClear}
                 dataTestId={dataTestId}
             />
         </div>

--- a/packages/amount-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/amount-input/src/__snapshots__/Component.test.tsx.snap
@@ -37,7 +37,7 @@ Object {
           
         </div>
         <div
-          class="component s component"
+          class="component s formControl component"
         >
           <div
             class="inner"
@@ -95,7 +95,7 @@ Object {
         
       </div>
       <div
-        class="component s component"
+        class="component s formControl component"
       >
         <div
           class="inner"
@@ -210,7 +210,7 @@ Object {
           
         </div>
         <div
-          class="component s component"
+          class="component s formControl component"
         >
           <div
             class="inner"
@@ -270,7 +270,7 @@ Object {
           
         </div>
         <div
-          class="component s filled component"
+          class="component s filled formControl component"
         >
           <div
             class="inner"
@@ -331,7 +331,7 @@ Object {
         
       </div>
       <div
-        class="component s filled component"
+        class="component s filled formControl component"
       >
         <div
           class="inner"

--- a/packages/bank-card/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/bank-card/src/__snapshots__/Component.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`BankCard Snapshots tests should match snapshots 1`] = `
           </svg>
         </div>
         <div
-          class="component s filled hasLabel block hasRightAddons"
+          class="component s filled hasLabel block hasRightAddons formControl"
         >
           <div
             class="inner"
@@ -139,7 +139,7 @@ exports[`BankCard Snapshots tests should match snapshots 2`] = `
           </svg>
         </div>
         <div
-          class="component s filled hasLabel block hasRightAddons"
+          class="component s filled hasLabel block hasRightAddons formControl"
         >
           <div
             class="inner"
@@ -245,7 +245,7 @@ exports[`BankCard Snapshots tests should match snapshots 3`] = `
           </svg>
         </div>
         <div
-          class="component s filled hasLabel block hasRightAddons"
+          class="component s filled hasLabel block hasRightAddons formControl"
         >
           <div
             class="inner"
@@ -351,7 +351,7 @@ exports[`BankCard Snapshots tests should match snapshots 4`] = `
           </svg>
         </div>
         <div
-          class="component s filled hasLabel block hasRightAddons"
+          class="component s filled hasLabel block hasRightAddons formControl"
         >
           <div
             class="inner"

--- a/packages/form-control/src/index.module.css
+++ b/packages/form-control/src/index.module.css
@@ -49,10 +49,6 @@
     box-sizing: border-box;
 }
 
-.component:not(.disabled) .inner {
-    cursor: pointer;
-}
-
 .inputWrapper {
     flex-grow: 1;
     position: relative;

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -16,6 +16,8 @@
         "react": "^16.9.0"
     },
     "dependencies": {
-        "@alfalab/core-components-form-control": "^1.2.1"
+        "@alfalab/core-components-form-control": "^1.2.1",
+        "@alfalab/core-components-button": "^1.4.0",
+        "@alfalab/icons-glyph": "^1.26.0"
     }
 }

--- a/packages/input/src/Component.stories.mdx
+++ b/packages/input/src/Component.stories.mdx
@@ -42,6 +42,7 @@ import { Input } from '@alfalab/core-components-input';
             'text',
         )}
         block={boolean('block', false)}
+        clear={boolean('clear', false)}
         size={select('size', ['s', 'm', 'l'], 's')}
         disabled={boolean('disabled', false)}
         placeholder={text('placeholder', '')}

--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -96,7 +96,7 @@ describe('Input', () => {
 
         it('should show clear button only if input has value', () => {
             const cb = jest.fn();
-            const label = 'очистить';
+            const label = 'Очистить';
             // toBeVisible не работает
             const visibleClass = 'clearButtonVisible';
             const { getByLabelText, rerender } = render(<Input onClear={cb} clear={true} />);
@@ -115,7 +115,7 @@ describe('Input', () => {
                 <Input clear={true} value={value} dataTestId={dataTestId} />,
             );
 
-            userEvent.click(getByLabelText('очистить'));
+            userEvent.click(getByLabelText('Очистить'));
 
             expect(getByTestId(dataTestId)).toHaveValue(value);
         });
@@ -154,7 +154,7 @@ describe('Input', () => {
         it('should show clear button only if input has value', async () => {
             const cb = jest.fn();
             const dataTestId = 'test-id';
-            const label = 'очистить';
+            const label = 'Очистить';
             // toBeVisible не работает
             const visibleClass = 'clearButtonVisible';
 
@@ -181,7 +181,7 @@ describe('Input', () => {
 
             await userEvent.type(input, '123');
 
-            userEvent.click(getByLabelText('очистить'));
+            userEvent.click(getByLabelText('Очистить'));
 
             expect(input).toHaveValue('');
         });
@@ -240,7 +240,7 @@ describe('Input', () => {
             const cb = jest.fn();
             const { getByLabelText } = render(<Input onClear={cb} clear={true} value='123' />);
 
-            userEvent.click(getByLabelText('очистить'));
+            userEvent.click(getByLabelText('Очистить'));
 
             expect(cb).toBeCalledTimes(1);
         });

--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -33,6 +33,13 @@ describe('Input', () => {
         expect(getByTestId(dataTestId).tagName).toBe('INPUT');
     });
 
+    it('should set `disabled` atribute', () => {
+        const dataTestId = 'test-id';
+        const { getByTestId } = render(<Input disabled={true} dataTestId={dataTestId} />);
+
+        expect(getByTestId(dataTestId)).toHaveAttribute('disabled');
+    });
+
     describe('Classes tests', () => {
         it('should set `className` class to root', () => {
             const className = 'test-class';
@@ -58,71 +65,125 @@ describe('Input', () => {
             expect(container.getElementsByClassName(className)).toBeTruthy();
         });
 
-        describe('when component is controlled', () => {
-            it('should set `filled` class when value passed', () => {
-                const { container } = render(<Input value='some value' />);
-
-                expect(container.firstElementChild).toHaveClass('filled');
-            });
-
-            it('should not set `filled` class if the value is empty', () => {
-                const { container } = render(<Input value='' />);
-
-                expect(container.firstElementChild).not.toHaveClass('filled');
-            });
-
-            it('should unset `filled` class if the value becomes empty', () => {
-                const { container, rerender } = render(<Input value='some value' />);
-
-                rerender(<Input value='' />);
-
-                expect(container.firstElementChild).not.toHaveClass('filled');
-            });
-        });
-
-        describe('when component is uncontrolled', () => {
-            it('should set `filled` class when defaultValue passed', () => {
-                const { container } = render(<Input defaultValue='some value' />);
-
-                expect(container.firstElementChild).toHaveClass('filled');
-            });
-
-            it('should not set `filled` class if the value is empty', () => {
-                const { container } = render(<Input />);
-
-                expect(container.firstElementChild).not.toHaveClass('filled');
-            });
-
-            it('should unset `filled` class if value becomes empty', async () => {
-                const dataTestId = 'test-id';
-                const { getByTestId } = render(
-                    <Input defaultValue='some value' dataTestId={dataTestId} />,
-                );
-
-                const input = getByTestId(dataTestId) as HTMLInputElement;
-
-                input.setSelectionRange(0, input.value.length);
-                await userEvent.type(input, '{backspace}');
-
-                input.blur();
-
-                expect(input.value).toBe('');
-                expect(input).not.toHaveClass('filled');
-            });
-        });
-
         it('should set `hasLabel` class', () => {
             const dataTestId = 'test-id';
             const { getByTestId } = render(<Input label='label' dataTestId={dataTestId} />);
 
             expect(getByTestId(dataTestId)).toHaveClass('hasLabel');
         });
+    });
 
-        it('should set `disabled` atribute', () => {
+    describe('when component is controlled', () => {
+        it('should set `filled` class when value passed', () => {
+            const { container } = render(<Input value='some value' />);
+
+            expect(container.firstElementChild).toHaveClass('filled');
+        });
+
+        it('should not set `filled` class if the value is empty', () => {
+            const { container } = render(<Input value='' />);
+
+            expect(container.firstElementChild).not.toHaveClass('filled');
+        });
+
+        it('should unset `filled` class if the value becomes empty', () => {
+            const { container, rerender } = render(<Input value='some value' />);
+
+            rerender(<Input value='' />);
+
+            expect(container.firstElementChild).not.toHaveClass('filled');
+        });
+
+        it('should show clear button only if input has value', () => {
+            const cb = jest.fn();
+            const label = 'очистить';
+            // toBeVisible не работает
+            const visibleClass = 'clearButtonVisible';
+            const { getByLabelText, rerender } = render(<Input onClear={cb} clear={true} />);
+
+            expect(getByLabelText(label)).not.toHaveClass(visibleClass);
+
+            rerender(<Input onClear={cb} clear={true} value='123' />);
+
+            expect(getByLabelText(label)).toHaveClass(visibleClass);
+        });
+
+        it('should not actually clear input when clear button clicked', () => {
             const dataTestId = 'test-id';
-            const { getByTestId } = render(<Input disabled={true} dataTestId={dataTestId} />);
+            const value = '123';
+            const { getByTestId, getByLabelText } = render(
+                <Input clear={true} value={value} dataTestId={dataTestId} />,
+            );
 
-            expect(getByTestId(dataTestId)).toHaveAttribute('disabled');
+            userEvent.click(getByLabelText('очистить'));
+
+            expect(getByTestId(dataTestId)).toHaveValue(value);
+        });
+    });
+
+    describe('when component is uncontrolled', () => {
+        it('should set `filled` class when defaultValue passed', () => {
+            const { container } = render(<Input defaultValue='some value' />);
+
+            expect(container.firstElementChild).toHaveClass('filled');
+        });
+
+        it('should not set `filled` class if the value is empty', () => {
+            const { container } = render(<Input />);
+
+            expect(container.firstElementChild).not.toHaveClass('filled');
+        });
+
+        it('should unset `filled` class if value becomes empty', async () => {
+            const dataTestId = 'test-id';
+            const { getByTestId } = render(
+                <Input defaultValue='some value' dataTestId={dataTestId} />,
+            );
+
+            const input = getByTestId(dataTestId) as HTMLInputElement;
+
+            input.setSelectionRange(0, input.value.length);
+            await userEvent.type(input, '{backspace}');
+
+            input.blur();
+
+            expect(input.value).toBe('');
+            expect(input).not.toHaveClass('filled');
+        });
+
+        it('should show clear button only if input has value', async () => {
+            const cb = jest.fn();
+            const dataTestId = 'test-id';
+            const label = 'очистить';
+            // toBeVisible не работает
+            const visibleClass = 'clearButtonVisible';
+
+            const { getByLabelText, getByTestId } = render(
+                <Input onClear={cb} clear={true} dataTestId={dataTestId} />,
+            );
+
+            const input = getByTestId(dataTestId) as HTMLInputElement;
+
+            expect(getByLabelText(label)).not.toHaveClass(visibleClass);
+
+            await userEvent.type(input, '123');
+
+            expect(getByLabelText(label)).toHaveClass(visibleClass);
+        });
+
+        it('should clear input when clear button clicked', async () => {
+            const dataTestId = 'test-id';
+            const { getByTestId, getByLabelText } = render(
+                <Input clear={true} dataTestId={dataTestId} />,
+            );
+
+            const input = getByTestId(dataTestId) as HTMLInputElement;
+
+            await userEvent.type(input, '123');
+
+            userEvent.click(getByLabelText('очистить'));
+
+            expect(input).toHaveValue('');
         });
     });
 
@@ -173,6 +234,15 @@ describe('Input', () => {
             await userEvent.type(input, '123');
 
             expect(cb).not.toBeCalled();
+        });
+
+        it('should call `onClear` prop when clear button clicked', () => {
+            const cb = jest.fn();
+            const { getByLabelText } = render(<Input onClear={cb} clear={true} value='123' />);
+
+            userEvent.click(getByLabelText('очистить'));
+
+            expect(cb).toBeCalledTimes(1);
         });
     });
 

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -209,30 +209,34 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     onClear(event);
                 }
 
-                if (inputRef.current) {
+                if (inputRef.current && !focused) {
                     inputRef.current.focus();
                 }
             },
-            [clearButtonVisible, onClear, uncontrolled],
+            [clearButtonVisible, focused, onClear, uncontrolled],
         );
 
-        const handleFormControlClear = useCallback((event: MouseEvent<HTMLDivElement>) => {
-            /**
-             * Инпут занимает не весь контрол, из-за этого появляются некликабельные области.
-             * Переводим фокус на инпут, если клик был совершен по неинтерактивному элементу.
-             */
-            const target = event.target as HTMLDivElement;
+        const handleFormControlMouseDown = useCallback(
+            (event: MouseEvent<HTMLElement>) => {
+                if (!inputRef.current) return;
 
-            if (target.tabIndex < 0 && inputRef.current) {
-                inputRef.current.focus();
-            }
-        }, []);
+                // Инпут занимает не весь контрол, из-за этого появляются некликабельные области или теряется фокус.
+                if (event.target !== inputRef.current) {
+                    event.preventDefault();
+                    if (!focused) {
+                        inputRef.current.focus();
+                    }
+                }
+            },
+            [focused],
+        );
 
         const renderRightAddons = () =>
             (clear || rightAddons) && (
                 <Fragment>
                     {clear && (
                         <Button
+                            type='button'
                             view='ghost'
                             onClick={handleClear}
                             leftAddons={clearIcon}
@@ -263,7 +267,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 leftAddons={leftAddons}
                 rightAddons={renderRightAddons()}
                 bottomAddons={bottomAddons}
-                onClick={handleFormControlClear}
+                onMouseDown={handleFormControlMouseDown}
             >
                 <input
                     {...restProps}

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -12,7 +12,6 @@ import cn from 'classnames';
 import mergeRefs from 'react-merge-refs';
 import { Button } from '@alfalab/core-components-button';
 import { FormControl } from '@alfalab/core-components-form-control';
-import { CrossCircleMIcon } from '@alfalab/icons-glyph';
 
 import styles from './index.module.css';
 
@@ -39,11 +38,6 @@ export type InputProps = Omit<
      * Крестик для очистки поля
      */
     clear?: boolean;
-
-    /**
-     * Иконка кнопки очистки
-     */
-    clearIcon?: ReactNode;
 
     /**
      * Размер компонента
@@ -131,7 +125,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className,
             dataTestId,
             clear = false,
-            clearIcon = <CrossCircleMIcon />,
             disabled,
             error,
             hint,
@@ -239,13 +232,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                             type='button'
                             view='ghost'
                             onClick={handleClear}
-                            leftAddons={clearIcon}
                             disabled={disabled}
-                            aria-label='очистить'
+                            aria-label='Очистить'
                             className={cn(styles.clearButton, {
                                 [styles.clearButtonVisible]: clearButtonVisible,
                             })}
-                        />
+                        >
+                            <span className={cn(styles.clearIcon)} />
+                        </Button>
                     )}
                     {rightAddons}
                 </Fragment>

--- a/packages/input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input/src/__snapshots__/Component.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="component s filled"
+        class="component s filled formControl"
       >
         <div
           class="inner"
@@ -31,7 +31,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="component s filled"
+      class="component s filled formControl"
     >
       <div
         class="inner"

--- a/packages/input/src/index.module.css
+++ b/packages/input/src/index.module.css
@@ -1,9 +1,7 @@
 @import '../../themes/src/default.css';
 
 :root {
-    --input-clear-button-fill: var(--color-light-graphic-tertiary);
-    --input-clear-button-fill-hover: var(--color-light-graphic-secondary);
-    --input-clear-button-fill-active: var(--color-light-graphic-primary);
+    --input-clear-icon: url('https://alfabank.st/icons/glyph_cross-circle_m.svg');
 }
 
 .input {
@@ -44,18 +42,24 @@
 
 .clearButton {
     visibility: hidden;
-    color: var(--input-clear-button-fill);
+}
+
+.clearIcon {
+    display: block;
+    width: 24px;
+    height: 24px;
+    background-image: var(--input-clear-icon);
+    background-repeat: no-repeat;
+    background-position: 50% 50%;
+    opacity: 0.3;
+    transition: opacity 0.2s ease;
 
     &:hover {
-        color: var(--input-clear-button-fill-hover);
+        opacity: 0.6;
     }
 
     &:active {
-        color: var(--input-clear-button-fill-active);
-    }
-
-    & svg {
-        transition: fill 0.2s ease;
+        opacity: 1;
     }
 }
 

--- a/packages/input/src/index.module.css
+++ b/packages/input/src/index.module.css
@@ -1,5 +1,11 @@
 @import '../../themes/src/default.css';
 
+:root {
+    --input-clear-button-fill: var(--color-light-graphic-tertiary);
+    --input-clear-button-fill-hover: var(--color-light-graphic-secondary);
+    --input-clear-button-fill-active: var(--color-light-graphic-primary);
+}
+
 .input {
     @mixin system_16-20_regular;
 
@@ -30,6 +36,31 @@
 
 .block {
     width: 100%;
+}
+
+.formControl:not(.disabled) {
+    cursor: text;
+}
+
+.clearButton {
+    visibility: hidden;
+
+    & svg {
+        transition: fill 0.2s ease;
+        fill: var(--input-clear-button-fill);
+
+        &:hover {
+            fill: var(--input-clear-button-fill-hover);
+        }
+
+        &:active {
+            fill: var(--input-clear-button-fill-active);
+        }
+    }
+}
+
+.clearButtonVisible {
+    visibility: visible;
 }
 
 /* DISABLED STATE */

--- a/packages/input/src/index.module.css
+++ b/packages/input/src/index.module.css
@@ -44,18 +44,18 @@
 
 .clearButton {
     visibility: hidden;
+    color: var(--input-clear-button-fill);
+
+    &:hover {
+        color: var(--input-clear-button-fill-hover);
+    }
+
+    &:active {
+        color: var(--input-clear-button-fill-active);
+    }
 
     & svg {
         transition: fill 0.2s ease;
-        fill: var(--input-clear-button-fill);
-
-        &:hover {
-            fill: var(--input-clear-button-fill-hover);
-        }
-
-        &:active {
-            fill: var(--input-clear-button-fill-active);
-        }
     }
 }
 

--- a/packages/input/tsconfig.json
+++ b/packages/input/tsconfig.json
@@ -6,8 +6,10 @@
         "rootDirs": ["src"],
         "baseUrl": ".",
         "paths": {
-            "@alfalab/core-components-form-control": ["../form-control/src"]
+            "@alfalab/core-components-button": ["../button/src"],
+            "@alfalab/core-components-form-control": ["../form-control/src"],
+            "@alfalab/core-components-loader": ["../loader/src"]
         }
     },
-    "references": [{ "path": "../form-control" }]
+    "references": [{ "path": "../button" }, { "path": "../form-control" }, { "path": "../loader" }]
 }

--- a/packages/masked-input/src/Component.tsx
+++ b/packages/masked-input/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback, ChangeEvent, useState } from 'react';
+import React, { useEffect, useRef, useCallback, ChangeEvent, useState, MouseEvent } from 'react';
 import cn from 'classnames';
 import mergeRefs from 'react-merge-refs';
 import { createTextMaskInputElement, TextMaskConfig, TextMaskInputElement } from 'text-mask-core';
@@ -23,7 +23,10 @@ export type MaskedInputProps = InputProps & {
 export const PLACEHOLDER_CHAR = '\u2000';
 
 export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
-    ({ mask, value, defaultValue, className, onBeforeDisplay, onChange, ...restProps }, ref) => {
+    (
+        { mask, value, defaultValue, className, onBeforeDisplay, onChange, onClear, ...restProps },
+        ref,
+    ) => {
         const inputRef = useRef<HTMLInputElement>(null);
         const textMask = useRef<TextMaskInputElement | null>(null);
 
@@ -49,6 +52,14 @@ export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
                 }
             },
             [onChange, update],
+        );
+
+        const handleClear = useCallback(
+            (event: MouseEvent<HTMLButtonElement>) => {
+                update('');
+                if (onClear) onClear(event);
+            },
+            [onClear, update],
         );
 
         useEffect(() => {
@@ -82,6 +93,7 @@ export const MaskedInput = React.forwardRef<HTMLInputElement, MaskedInputProps>(
                 className={cn(className, { [styles.textHidden]: textHidden })}
                 value={inputValue}
                 onChange={handleInputChange}
+                onClear={handleClear}
                 ref={mergeRefs([ref, inputRef])}
             />
         );

--- a/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="component s"
+        class="component s formControl"
       >
         <div
           class="inner"
@@ -31,7 +31,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="component s"
+      class="component s formControl"
     >
       <div
         class="inner"

--- a/packages/phone-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/phone-input/src/__snapshots__/Component.test.tsx.snap
@@ -6,7 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="component s"
+        class="component s formControl"
       >
         <div
           class="inner"
@@ -31,7 +31,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="component s"
+      class="component s formControl"
     >
       <div
         class="inner"

--- a/packages/select/src/components/autocomplete/Component.stories.mdx
+++ b/packages/select/src/components/autocomplete/Component.stories.mdx
@@ -86,7 +86,6 @@ export const matchOption = (option, inputValue) =>
 <Preview>
     <div style={{ height: 180 }}>
         {React.createElement(() => {
-            const inputRef = React.useRef(null);
             const [value, setValue] = React.useState('');
             const handleInput = event => {
                 setValue(event.target.value);
@@ -95,25 +94,8 @@ export const matchOption = (option, inputValue) =>
                 setValue(selectedOptions.map(option => option.text).join(', '));
             };
             const handleClear = (event) => {
-                event.stopPropagation();
-                event.preventDefault();
-                if (inputRef.current) {
-                    inputRef.current.focus();
-                }
                 setValue('');
             };
-            const renderAddons = () => (
-                value.length > 0 ? (
-                    <button
-                        type='button'
-                        onClick={handleClear}
-                        onKeyDown={handleClear}
-                        style={{ display: 'flex', border: 'none', background: 'none', padding: 0 }}
-                    >
-                        <CloseMBlackIcon />
-                    </button>
-                ) : null
-            );
             const filteredOptions = options.filter(option => matchOption(option, value));
             return (
                 <Autocomplete
@@ -125,10 +107,9 @@ export const matchOption = (option, inputValue) =>
                     onChange={handleChange}
                     onInput={handleInput}
                     value={value}
-                    Arrow={value.length === 0 ? Arrow : null}
-                    ref={inputRef}
                     inputProps={{
-                        rightAddons: renderAddons(),
+                        clear: true,
+                        onClear: handleClear
                     }}
                 />
             );

--- a/packages/select/src/components/field/index.module.css
+++ b/packages/select/src/components/field/index.module.css
@@ -3,6 +3,7 @@
 .component {
     width: 100%;
     outline: none;
+    cursor: pointer;
 }
 
 .placeholder {


### PR DESCRIPTION
- Добавлен крестик для очистки поля
- Обновлены зависимые компоненты
- Добавлены тесты
- Небольшие правки и code-style
- Инпут сделан более отзывчивым - фокус не теряется при клике в любой области поля, кроме кнопок

При очистке поля происходит событие MouseEvent<кнопка>, т.е. событие onChange не вызывается. Поэтому у controlled-инпутов нужно подписываться на onClear и очищать значение.