### PR TITLE
fix: delete prop tag span

### DIFF
--- a/packages/typography/src/text/Component.tsx
+++ b/packages/typography/src/text/Component.tsx
@@ -32,7 +32,7 @@ export type TextProps = {
     /**
      * HTML тег
      */
-    tag?: 'p' | 'span' | 'div';
+    tag?: 'p' | 'div';
 
     /**
      * Css-класс для стилизации


### PR DESCRIPTION
# Опишите проблему
Раз `span` ставится по-умолчанию, то может возможность его ставить руками не нужна?
