### PR TITLE
fix(core-components-input): keep focus only inside control

### DIFF
--- a/packages/form-control/src/Component.test.tsx
+++ b/packages/form-control/src/Component.test.tsx
@@ -9,12 +9,11 @@ describe('FormControl', () => {
             expect(render(<FormControl />)).toMatchSnapshot();
         });
 
-        it('should forward ref to FormControl', () => {
+        it('should forward ref to control wrapper', () => {
             const ref = jest.fn();
-            const dataTestId = 'test-id';
-            const { getByTestId } = render(<FormControl ref={ref} dataTestId={dataTestId} />);
+            render(<FormControl ref={ref} />);
 
-            expect(ref.mock.calls).toEqual([[getByTestId(dataTestId)]]);
+            expect(ref.mock.calls[0][0].className).toBe('inner');
         });
 
         it('should render label', () => {

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -107,7 +107,6 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
 
         return (
             <div
-                ref={ref}
                 data-test-id={dataTestId}
                 className={cn(
                     styles.component,
@@ -126,7 +125,7 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
                 )}
                 {...restProps}
             >
-                <div className={styles.inner}>
+                <div className={styles.inner} ref={ref}>
                     {leftAddons && (
                         <div className={cn(styles.addons, styles.leftAddons)}>{leftAddons}</div>
                     )}

--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -280,6 +280,34 @@ describe('Input', () => {
         });
     });
 
+    it.only('should keep focus when clicking inside control', () => {
+        const dataTestId = 'test-id';
+        const { getByTestId, getByText } = render(
+            <Input
+                dataTestId={dataTestId}
+                rightAddons='right'
+                leftAddons='left'
+                bottomAddons='bottom'
+            />,
+        );
+
+        userEvent.click(getByTestId(dataTestId));
+
+        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
+
+        userEvent.click(getByText('left'));
+
+        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
+
+        userEvent.click(getByText('right'));
+
+        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
+
+        userEvent.click(getByText('bottom'));
+
+        expect(document.activeElement && document.activeElement.tagName).not.toBe('INPUT');
+    });
+
     it('should unmount without errors', () => {
         const { unmount } = render(<Input value='value' onChange={jest.fn()} />);
 

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -159,6 +159,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         const uncontrolled = value === undefined;
 
         const inputRef = useRef<HTMLInputElement>(null);
+        const controlRef = useRef<HTMLDivElement>(null);
 
         const [focused, setFocused] = useState(false);
         const [stateValue, setStateValue] = useState(defaultValue || '');
@@ -222,11 +223,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         );
 
         const handleFormControlMouseDown = useCallback(
-            (event: MouseEvent<HTMLElement>) => {
-                if (!inputRef.current) return;
+            (event: MouseEvent<HTMLDivElement>) => {
+                if (!inputRef.current || !controlRef.current) return;
 
                 // Инпут занимает не весь контрол, из-за этого появляются некликабельные области или теряется фокус.
-                if (event.target !== inputRef.current) {
+                if (
+                    event.target !== inputRef.current &&
+                    controlRef.current.contains(event.target as HTMLDivElement)
+                ) {
                     event.preventDefault();
                     if (!focused) {
                         inputRef.current.focus();
@@ -259,7 +263,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         return (
             <FormControl
-                ref={wrapperRef}
+                ref={mergeRefs([controlRef, wrapperRef || null])}
                 className={cn(
                     styles.formControl,
                     className,

--- a/packages/slider-input/src/Component.tsx
+++ b/packages/slider-input/src/Component.tsx
@@ -1,12 +1,4 @@
-import React, {
-    forwardRef,
-    useCallback,
-    ChangeEvent,
-    FC,
-    ReactNode,
-    MouseEvent,
-    Fragment,
-} from 'react';
+import React, { forwardRef, useCallback, ChangeEvent, FC, ReactNode, Fragment } from 'react';
 import cn from 'classnames';
 import { Slider } from '@alfalab/core-components-slider';
 import { Input as DefaultInput, InputProps } from '@alfalab/core-components-input';
@@ -138,10 +130,6 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
             [onChange, onInputChange],
         );
 
-        const handleSliderMouseDown = useCallback((event: MouseEvent<HTMLInputElement>) => {
-            event.stopPropagation();
-        }, []);
-
         return (
             <div
                 className={cn(
@@ -178,7 +166,6 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                             value={Number.isNaN(+sliderValue) ? undefined : sliderValue}
                             disabled={disabled}
                             className={cn(styles.slider, sliderClassName)}
-                            onMouseDown={handleSliderMouseDown}
                         />
                     }
                     rightAddons={


### PR DESCRIPTION
## Контекст 
Инпут занимает не весь контрол, из-за этого появляются некликабельные области или теряется фокус:

<img src="https://user-images.githubusercontent.com/9968618/94825113-742b9a80-040e-11eb-84d9-84620930144e.png" width="300" />

Для этого есть обработка mouseDown внутри инпута.

## Изменение 
Теперь фокус сохраняется только при клике в области контрола, а не всего компонента:

<img src="https://user-images.githubusercontent.com/9968618/94824534-d1731c00-040d-11eb-839c-4d024f4225fc.png" width="480" />