### PR TITLE
ci: add build concurrency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,3 +33,5 @@ jobs:
             
             - name: Run build
               run: yarn build
+              env:
+                BUILD_CONCURRENCY: 5

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,8 +5,13 @@ set -e
 # удаляю билды
 yarn clean
 
+# устанавливаем ограничение на количество параллельных процессов при сборке (default - 10)
+CONCURRENCY=${BUILD_CONCURRENCY:=10}
+
+echo "start build on $CONCURRENCY parallel process"
+
 # собираю все подпакеты, за исключением css-пакетов (vars, themes)
-lerna exec --parallel \
+lerna exec --concurrency $CONCURRENCY \
     --ignore @alfalab/core-components-vars \
     --ignore @alfalab/core-components-themes \
     -- $(pwd)/bin/rollup.sh


### PR DESCRIPTION
Добавил ограничение на количество процессов при сборке компонентов.
Один процесс использует примерно `300МБ` оперативной памяти.
Для локальной сборки выставил ограничение в `10` процессов, для сборки на гитхабе - `5` процессов.
По времени сборки особо разницы не заметил. 