### PR TITLE
fix(core-components-button): add text align

### DIFF
--- a/packages/button/src/index.module.css
+++ b/packages/button/src/index.module.css
@@ -42,6 +42,7 @@
     line-height: 1.2;
     font-weight: var(--button-font-weight);
     font-family: var(--font-family);
+    text-align: center;
     text-decoration: none;
     background-color: transparent;
     border: 0;


### PR DESCRIPTION
# Опишите проблему
Когда `Button` используется как ссылка - выравнивание текста меняется на `left` 

# Шаги для воспроизведения
См. видео https://take.ms/zkY4t

# Ожидаемое поведение
Тип кнопки не меняет выравнивание текста.