### PR TITLE
refactor(core-components-input): remove mousedown handler

### DIFF
--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -119,15 +119,14 @@ describe('Input', () => {
         it('should show clear button only if input has value', () => {
             const cb = jest.fn();
             const label = 'Очистить';
-            // toBeVisible не работает
-            const visibleClass = 'clearButtonVisible';
-            const { getByLabelText, rerender } = render(<Input onClear={cb} clear={true} />);
 
-            expect(getByLabelText(label)).not.toHaveClass(visibleClass);
+            const { queryByLabelText, rerender } = render(<Input onClear={cb} clear={true} />);
+
+            expect(queryByLabelText(label)).not.toBeInTheDocument();
 
             rerender(<Input onClear={cb} clear={true} value='123' />);
 
-            expect(getByLabelText(label)).toHaveClass(visibleClass);
+            expect(queryByLabelText(label)).toBeInTheDocument();
         });
 
         it('should not actually clear input when clear button clicked', () => {
@@ -189,20 +188,18 @@ describe('Input', () => {
             const cb = jest.fn();
             const dataTestId = 'test-id';
             const label = 'Очистить';
-            // toBeVisible не работает
-            const visibleClass = 'clearButtonVisible';
 
-            const { getByLabelText, getByTestId } = render(
+            const { queryByLabelText, getByTestId } = render(
                 <Input onClear={cb} clear={true} dataTestId={dataTestId} />,
             );
 
             const input = getByTestId(dataTestId) as HTMLInputElement;
 
-            expect(getByLabelText(label)).not.toHaveClass(visibleClass);
+            expect(queryByLabelText(label)).not.toBeInTheDocument();
 
             await userEvent.type(input, '123');
 
-            expect(getByLabelText(label)).toHaveClass(visibleClass);
+            expect(queryByLabelText(label)).toBeInTheDocument();
         });
 
         it('should clear input when clear button clicked', async () => {
@@ -278,34 +275,6 @@ describe('Input', () => {
 
             expect(cb).toBeCalledTimes(1);
         });
-    });
-
-    it.only('should keep focus when clicking inside control', () => {
-        const dataTestId = 'test-id';
-        const { getByTestId, getByText } = render(
-            <Input
-                dataTestId={dataTestId}
-                rightAddons='right'
-                leftAddons='left'
-                bottomAddons='bottom'
-            />,
-        );
-
-        userEvent.click(getByTestId(dataTestId));
-
-        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
-
-        userEvent.click(getByText('left'));
-
-        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
-
-        userEvent.click(getByText('right'));
-
-        expect(document.activeElement && document.activeElement.tagName).toBe('INPUT');
-
-        userEvent.click(getByText('bottom'));
-
-        expect(document.activeElement && document.activeElement.tagName).not.toBe('INPUT');
     });
 
     it('should unmount without errors', () => {

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -169,7 +169,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         const filled = Boolean(uncontrolled ? stateValue : value);
         // отображаем крестик только для заполненного и активного инпута
-        const clearButtonVisible = Boolean(value || (uncontrolled && stateValue)) && !disabled;
+        const clearButtonVisible =
+            clear && Boolean(value || (uncontrolled && stateValue)) && !disabled;
 
         const handleInputFocus = useCallback(
             (event: React.FocusEvent<HTMLInputElement>) => {
@@ -225,37 +226,17 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             [clearButtonVisible, focused, onClear, uncontrolled],
         );
 
-        const handleFormControlMouseDown = useCallback(
-            (event: MouseEvent<HTMLDivElement>) => {
-                if (!inputRef.current || !controlRef.current) return;
-
-                // Инпут занимает не весь контрол, из-за этого появляются некликабельные области или теряется фокус.
-                if (
-                    event.target !== inputRef.current &&
-                    controlRef.current.contains(event.target as HTMLDivElement)
-                ) {
-                    event.preventDefault();
-                    if (!focused) {
-                        inputRef.current.focus();
-                    }
-                }
-            },
-            [focused],
-        );
-
         const renderRightAddons = () =>
-            (clear || rightAddons) && (
+            (clearButtonVisible || rightAddons) && (
                 <Fragment>
-                    {clear && (
+                    {clearButtonVisible && (
                         <Button
                             type='button'
                             view='ghost'
-                            onClick={handleClear}
                             disabled={disabled}
                             aria-label='Очистить'
-                            className={cn(styles.clearButton, {
-                                [styles.clearButtonVisible]: clearButtonVisible,
-                            })}
+                            className={styles.clearButton}
+                            onClick={handleClear}
                         >
                             <span className={cn(styles.clearIcon)} />
                         </Button>
@@ -289,7 +270,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 leftAddons={leftAddons}
                 rightAddons={renderRightAddons()}
                 bottomAddons={bottomAddons}
-                onMouseDown={handleFormControlMouseDown}
             >
                 <input
                     {...restProps}

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -68,7 +68,7 @@ export type InputProps = Omit<
     /**
      * Ref для обертки input
      */
-    wrapperRef?: React.Ref<HTMLDivElement | null>;
+    wrapperRef?: React.Ref<HTMLDivElement>;
 
     /**
      * Слот слева
@@ -160,7 +160,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         const uncontrolled = value === undefined;
 
         const inputRef = useRef<HTMLInputElement>(null);
-        const controlRef = useRef<HTMLDivElement>(null);
 
         const [focusVisible] = useFocus(inputRef, 'keyboard');
 
@@ -247,7 +246,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         return (
             <FormControl
-                ref={mergeRefs([controlRef, wrapperRef || null])}
+                ref={wrapperRef}
                 className={cn(
                     styles.formControl,
                     className,

--- a/packages/input/src/index.module.css
+++ b/packages/input/src/index.module.css
@@ -36,14 +36,6 @@
     width: 100%;
 }
 
-.formControl:not(.disabled) {
-    cursor: text;
-}
-
-.clearButton {
-    visibility: hidden;
-}
-
 .clearIcon {
     display: block;
     width: 24px;
@@ -61,10 +53,6 @@
     &:active {
         opacity: 1;
     }
-}
-
-.clearButtonVisible {
-    visibility: visible;
 }
 
 /* DISABLED STATE */


### PR DESCRIPTION
Частично откатил этот PR - https://github.com/alfa-laboratory/core-components/pull/294
В некоторых кейсах это вызывало проблему, поэтому убрал обработчик onMouseDown.