### PR TITLE
refactor(core-components-select): inputs & types

### DIFF
--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -129,9 +129,8 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
                     },
                     className,
                 )}
-                {...restProps}
             >
-                <div className={styles.inner} ref={ref}>
+                <div {...restProps} className={styles.inner} ref={ref}>
                     {leftAddons && (
                         <div className={cn(styles.addons, styles.leftAddons, addonsClassName)}>
                             {leftAddons}

--- a/packages/form-control/src/index.module.css
+++ b/packages/form-control/src/index.module.css
@@ -48,6 +48,7 @@
     border-bottom: var(--form-control-border-bottom);
     transition: background 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
     box-sizing: border-box;
+    outline: none;
 }
 
 .inputWrapper {

--- a/packages/input-autocomplete/src/Component.stories.mdx
+++ b/packages/input-autocomplete/src/Component.stories.mdx
@@ -12,25 +12,25 @@ import { Arrow, Option } from '@alfalab/core-components-select';
 import { InputAutocomplete } from './Component';
 
 export const options = [
-    { value: '1', text: 'Neptunium'},
-    { value: '2', text: 'Plutonium' },
-    { value: '3', text: 'Americium' },
-    { value: '4', text: 'Curium' },
-    { value: '5', text: 'Berkelium' },
-    { value: '6', text: 'Californium' },
-    { value: '7', text: 'Einsteinium' },
-    { value: '8', text: 'Fermium' },
-    { value: '9', text: 'Mendelevium' },
-    { value: '10', text: 'Nobelium' },
-    { value: '11', text: 'Lawrencium' },
-    { value: '12', text: 'Rutherfordium' },
-    { value: '13', text: 'Dubnium' },
-    { value: '14', text: 'Seaborgium' },
-    { value: '15', text: 'Bohrium' },
+    { key: 'Neptunium', content: 'Neptunium' },
+    { key: 'Plutonium', content: 'Plutonium' },
+    { key: 'Americium', content: 'Americium' },
+    { key: 'Curium', content: 'Curium' },
+    { key: 'Berkelium', content: 'Berkelium' },
+    { key: 'Californium', content: 'Californium' },
+    { key: 'Einsteinium', content: 'Einsteinium' },
+    { key: 'Fermium', content: 'Fermium' },
+    { key: 'Mendelevium', content: 'Mendelevium' },
+    { key: 'Nobelium', content: 'Nobelium' },
+    { key: 'Lawrencium', content: 'Lawrencium' },
+    { key: 'Rutherfordium', content: 'Rutherfordium' },
+    { key: 'Dubnium', content: 'Dubnium' },
+    { key: 'Seaborgium', content: 'Seaborgium' },
+    { key: 'Bohrium', content: 'Bohrium' },
 ];
 
 export const matchOption = (option, inputValue) =>
-    option.text.toLowerCase().includes(inputValue.toLowerCase());
+    option.content.toLowerCase().includes(inputValue.toLowerCase());
 
 
 <Meta
@@ -48,8 +48,8 @@ export const matchOption = (option, inputValue) =>
         const handleInput = event => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            setValue(selectedOptions.map(option => option.text).join(', '));
+        const handleChange = ({ selected }) => {
+            setValue(selected ? selected.key : null);
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (
@@ -92,8 +92,8 @@ export const matchOption = (option, inputValue) =>
         const handleInput = event => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            setValue(selectedOptions.map(option => option.text).join(', '));
+        const handleChange = ({ selected }) => {
+            setValue(selected ? selected.key : null);
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (
@@ -121,8 +121,8 @@ export const matchOption = (option, inputValue) =>
         const handleInput = event => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            setValue(selectedOptions.map(option => option.text).join(', '));
+        const handleChange = ({ selected }) => {
+            setValue(selected ? selected.key : null);
         };
         const handleClear = (event) => {
             setValue('');
@@ -153,25 +153,24 @@ export const matchOption = (option, inputValue) =>
 <Preview>
     {React.createElement(() => {
         const [value, setValue] = React.useState('');
-        const [selected, setSelected] = React.useState([]);
+        const [selectedTags, setSelectedTags] = React.useState([]);
         const handleInput = event => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
+        const handleChange = ({ selected }) => {
             setValue('');
-            const selectedText = selectedOptions.length ? selectedOptions[0].text : '';
-            if (selectedText && !selected.includes(selectedText)) {
-                setSelected(selected.concat([selectedText]));
+            if (selected && !selectedTags.includes(selected.key)) {
+                setSelectedTags(selectedTags.concat([selected.key]));
             }
         };
-        const renderTags = () => selected.length > 0 ?
-            selected.map(item => <Tag key={item} size='xs'>{item}</Tag>) :
+        const renderTags = () => selectedTags.length > 0 ?
+            selectedTags.map(item => <Tag key={item} size='xs'>{item}</Tag>) :
             null;
         const filteredOptions = options
-            .filter(option => !selected.includes(option.text))
+            .filter(option => !selectedTags.includes(option.content))
             .filter(option => matchOption(option, value));
         if (filteredOptions.length === 0 && value) {
-            filteredOptions.push({ text: value, value });
+            filteredOptions.push({ key: value, content: value });
         }
         return (
             <React.Fragment>
@@ -203,8 +202,8 @@ export const matchOption = (option, inputValue) =>
             if (!dirty) setDirty(true);
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            setValue(selectedOptions.length ? selectedOptions[0].text : '');
+        const handleChange = ({ selected }) => {
+            setValue(selected ? selected.key : null);
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (
@@ -229,37 +228,32 @@ export const matchOption = (option, inputValue) =>
         const mask = [/\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/, ' ', /\d/, /\d/, /\d/, /\d/];
         const cards = [
             {
-                text: '4035 5010 0000 0008',
-                name: 'Карта 1',
-                value: '4035 5010 0000 0008',
+                key: 'Карта 1',
+                content: '4035 5010 0000 0008',
             },
             {
-                text: '4360 0000 0100 0005',
-                name: 'Карта 2',
-                value: '4360 0000 0100 0005',
+                key: 'Карта 2',
+                content: '4360 0000 0100 0005',
             },
             {
-                text: '8171 9999 2766 0000',
-                name: 'Карта 3',
-                value: '8171 9999 2766 0000',
+                key: 'Карта 3',
+                content: '8171 9999 2766 0000',
             },
             {
-                text: '5204 2477 5000 1471',
-                name: 'Карта 4',
-                value: '5204 2477 5000 1471',
+                key: 'Карта 4',
+                content: '5204 2477 5000 1471',
             },
             {
-                text: '4111 1111 1111 1111',
-                name: 'Карта 5',
-                value: '4111 1111 1111 1111',
+                key: 'Карта 5',
+                content: '4111 1111 1111 1111',
             },
         ];
         const CardOption = React.forwardRef((props, ref) => (
             <Option {...props} ref={ref}>
                 <div>
-                    {props.option.name}
+                    {props.option.key}
                     <br />
-                    <sub>{props.option.text}</sub>
+                    <sub>{props.option.content}</sub>
                 </div>
             </Option>
         ));
@@ -267,8 +261,8 @@ export const matchOption = (option, inputValue) =>
         const handleInput = (event) => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            setValue(selectedOptions.length ? selectedOptions[0].text : '');
+        const handleChange = ({ selected }) => {
+            setValue(selected ? selected.content : null);
         };
         const filteredOptions = cards.filter(option => matchOption(option, value));
         return (
@@ -298,16 +292,16 @@ export const matchOption = (option, inputValue) =>
         const handleInput = event => {
             setValue(event.target.value);
         };
-        const handleChange = ({ selectedOptions }) => {
-            const value = selectedOptions.length
-                ? selectedOptions.map(option => option.text).join(', ') + ', '
+        const handleChange = ({ selectedMultiple }) => {
+            const value = selectedMultiple.length
+                ? selectedMultiple.map(option => option.key).join(', ') + ', '
                 : '';
             setValue(value);
         };
         const inputValues = value.split(',').map(v => v.trim()).filter(v => v);
         const selectedOptions = options
-            .filter(option => inputValues.includes(option.text.trim()));
-        const selected = selectedOptions.map(option => option.value);
+            .filter(option => inputValues.includes(option.content.trim()));
+        const selected = selectedOptions.map(option => option.key);
         const filteredOptions = inputValues.length === selected.length ?
             options :
             options.filter(option => {

--- a/packages/input-autocomplete/src/Component.stories.mdx
+++ b/packages/input-autocomplete/src/Component.stories.mdx
@@ -30,7 +30,7 @@ export const options = [
 ];
 
 export const matchOption = (option, inputValue) =>
-    option.content.toLowerCase().includes(inputValue.toLowerCase());
+    option.content.toLowerCase().includes((inputValue || '').toLowerCase());
 
 
 <Meta
@@ -49,7 +49,7 @@ export const matchOption = (option, inputValue) =>
             setValue(event.target.value);
         };
         const handleChange = ({ selected }) => {
-            setValue(selected ? selected.key : null);
+            setValue(selected ? selected.key : '');
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (
@@ -97,7 +97,7 @@ import { InputAutocomplete } from '@alfalab/core-components-input-autocomplete';
             setValue(event.target.value);
         };
         const handleChange = ({ selected }) => {
-            setValue(selected ? selected.key : null);
+            setValue(selected ? selected.key : '');
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (
@@ -126,7 +126,7 @@ import { InputAutocomplete } from '@alfalab/core-components-input-autocomplete';
             setValue(event.target.value);
         };
         const handleChange = ({ selected }) => {
-            setValue(selected ? selected.key : null);
+            setValue(selected ? selected.key : '');
         };
         const handleClear = (event) => {
             setValue('');
@@ -207,7 +207,7 @@ import { InputAutocomplete } from '@alfalab/core-components-input-autocomplete';
             setValue(event.target.value);
         };
         const handleChange = ({ selected }) => {
-            setValue(selected ? selected.key : null);
+            setValue(selected ? selected.key : '');
         };
         const filteredOptions = options.filter(option => matchOption(option, value));
         return (

--- a/packages/input-autocomplete/src/Component.stories.mdx
+++ b/packages/input-autocomplete/src/Component.stories.mdx
@@ -63,7 +63,7 @@ export const matchOption = (option, inputValue) =>
                 hint={text('hint', '')}
                 allowUnselect={boolean('allowUnselect', true)}
                 closeOnSelect={boolean('closeOnSelect', false)}
-                Arrow={boolean('Arrow', true) ? Arrow : undefined}
+                Arrow={boolean('Arrow', false) ? Arrow : undefined}
                 circularNavigation={boolean('circularNavigation', false)}
                 placeholder={text('placeholder', 'Введите элемент')}
                 label={text('label', 'Элемент')}
@@ -83,6 +83,10 @@ export const matchOption = (option, inputValue) =>
     name='InputAutocomplete'
     stage={1}
 />
+
+```tsx
+import { InputAutocomplete } from '@alfalab/core-components-input-autocomplete';
+```
 
 Компонент поля для ввода с автокомплитом
 
@@ -318,8 +322,15 @@ export const matchOption = (option, inputValue) =>
                 onInput={handleInput}
                 allowUnselect={true}
                 value={value}
-                Arrow={Arrow}
             />
         );
     })}
 </Preview>
+
+### Автокомплит со стрелкой
+
+```tsx
+import { Arrow } from '@alfalab/core-components/select';
+
+<InputAutocomplete Arrow={Arrow} />
+```

--- a/packages/input-autocomplete/src/Component.tsx
+++ b/packages/input-autocomplete/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ChangeEvent, forwardRef } from 'react';
+import React, { FC, ChangeEvent, forwardRef, RefAttributes } from 'react';
 import { InputProps } from '@alfalab/core-components-input';
 import {
     BaseSelectProps,
@@ -14,7 +14,7 @@ export type InputAutocompleteProps = Omit<BaseSelectProps, 'Field' | 'nativeSele
     /**
      * Компонент ввода значения
      */
-    Input?: FC<InputProps>;
+    Input?: FC<InputProps & RefAttributes<HTMLInputElement>>;
 
     /**
      * Пропсы, которые будут прокинуты в инпут

--- a/packages/input-autocomplete/src/autocomplete-field/Component.tsx
+++ b/packages/input-autocomplete/src/autocomplete-field/Component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Input as DefaultInput } from '@alfalab/core-components-input';
 import { FieldProps } from '@alfalab/core-components-select';
 import { InputAutocompleteProps } from '../Component';
@@ -18,27 +18,51 @@ export const AutocompleteField = ({
     disabled,
     onInput,
     inputProps = {},
-    innerProps = {},
-}: AutocompleteFieldProps) => (
-    <Input
-        {...innerProps}
-        {...inputProps}
-        wrapperRef={innerProps.ref}
-        disabled={disabled}
-        block={true}
-        label={label}
-        placeholder={placeholder}
-        size={size}
-        error={error}
-        hint={hint}
-        rightAddons={
-            <React.Fragment>
-                {inputProps.rightAddons}
-                {Arrow}
-            </React.Fragment>
-        }
-        onChange={onInput}
-        autoComplete='off'
-        value={value}
-    />
-);
+    innerProps,
+}: AutocompleteFieldProps) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const { onClick } = innerProps;
+
+    const handleMouseDown = useCallback(event => {
+        event.preventDefault();
+    }, []);
+
+    const handleClick = useCallback(
+        event => {
+            if (onClick) onClick(event);
+
+            if (inputRef.current) {
+                inputRef.current.focus();
+            }
+        },
+        [onClick],
+    );
+
+    return (
+        <Input
+            {...innerProps}
+            {...inputProps}
+            wrapperRef={innerProps.ref}
+            ref={inputRef}
+            disabled={disabled}
+            block={true}
+            label={label}
+            placeholder={placeholder}
+            size={size}
+            error={error}
+            hint={hint}
+            rightAddons={
+                <React.Fragment>
+                    {inputProps.rightAddons}
+                    {Arrow}
+                </React.Fragment>
+            }
+            onChange={onInput}
+            onMouseDown={handleMouseDown}
+            onClick={handleClick}
+            autoComplete='off'
+            value={value}
+        />
+    );
+};

--- a/packages/input-autocomplete/src/autocomplete-field/Component.tsx
+++ b/packages/input-autocomplete/src/autocomplete-field/Component.tsx
@@ -53,10 +53,12 @@ export const AutocompleteField = ({
             error={error}
             hint={hint}
             rightAddons={
-                <React.Fragment>
-                    {inputProps.rightAddons}
-                    {Arrow}
-                </React.Fragment>
+                (Arrow || inputProps.rightAddons) && (
+                    <React.Fragment>
+                        {inputProps.rightAddons}
+                        {Arrow}
+                    </React.Fragment>
+                )
             }
             onChange={onInput}
             onMouseDown={handleMouseDown}

--- a/packages/input-autocomplete/src/autocomplete-field/Component.tsx
+++ b/packages/input-autocomplete/src/autocomplete-field/Component.tsx
@@ -41,8 +41,8 @@ export const AutocompleteField = ({
 
     return (
         <Input
-            {...innerProps}
             {...inputProps}
+            {...innerProps}
             wrapperRef={innerProps.ref}
             ref={inputRef}
             disabled={disabled}

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -18,7 +18,7 @@ import styles from './index.module.css';
 
 export type InputProps = Omit<
     InputHTMLAttributes<HTMLInputElement>,
-    'size' | 'type' | 'value' | 'defaultValue' | 'onChange'
+    'size' | 'type' | 'value' | 'defaultValue' | 'onChange' | 'onClick' | 'onMouseDown'
 > & {
     /**
      * Значение поля ввода
@@ -126,6 +126,21 @@ export type InputProps = Omit<
     onClear?: (event: MouseEvent<HTMLButtonElement>) => void;
 
     /**
+     * Обработчик клика по полю
+     */
+    onClick?: (event: MouseEvent<HTMLDivElement>) => void;
+
+    /**
+     * Обработчик MouseDown по полю
+     */
+    onMouseDown?: (event: MouseEvent<HTMLDivElement>) => void;
+
+    /**
+     * Обработчик MouseUp по полю
+     */
+    onMouseUp?: (event: MouseEvent<HTMLDivElement>) => void;
+
+    /**
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
@@ -155,6 +170,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             onBlur,
             onChange,
             onClear,
+            onClick,
+            onMouseDown,
+            onMouseUp,
             rightAddons,
             value,
             defaultValue,
@@ -276,6 +294,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 leftAddons={leftAddons}
                 rightAddons={renderRightAddons()}
                 bottomAddons={bottomAddons}
+                onClick={onClick}
+                onMouseDown={onMouseDown}
+                onMouseUp={onMouseUp}
             >
                 <input
                     {...restProps}

--- a/packages/select/src/Component.stories.mdx
+++ b/packages/select/src/Component.stories.mdx
@@ -214,6 +214,10 @@ import { Select } from '@alfalab/core-components-select';
                 const formData = new FormData(form);
                 setSerialized(new URLSearchParams(formData).toString());
             };
+            const [selected, setSelected] = React.useState([]);
+            const handleChange = ({ selectedMultiple }) => {
+                setSelected(selectedMultiple.map(option => option.key));
+            };
             return (
                 <div>
                     <form onSubmit={onSubmit}>
@@ -223,6 +227,8 @@ import { Select } from '@alfalab/core-components-select';
                             placeholder='Выберите элемент'
                             name='select'
                             multiple={true}
+                            onChange={handleChange}
+                            selected={selected}
                         />
                         <button type='submit'>Отправить</button>
                     </form>

--- a/packages/select/src/Component.stories.mdx
+++ b/packages/select/src/Component.stories.mdx
@@ -19,52 +19,52 @@ import { name, version } from '../package.json';
 import Icon from '@alfalab/icons-classic/BankAlfaSBlackIcon';
 
 export const options = [
-    { value: '1', text: 'Neptunium'},
-    { value: '2', text: 'Plutonium' },
-    { value: '3', text: 'Americium' },
-    { value: '4', text: 'Curium' },
-    { value: '5', text: 'Berkelium' },
-    { value: '6', text: 'Californium' },
-    { value: '7', text: 'Einsteinium' },
-    { value: '8', text: 'Fermium' },
-    { value: '9', text: 'Mendelevium' },
-    { value: '10', text: 'Nobelium' },
-    { value: '11', text: 'Lawrencium' },
-    { value: '12', text: 'Rutherfordium' },
-    { value: '13', text: 'Dubnium' },
-    { value: '14', text: 'Seaborgium' },
-    { value: '15', text: 'Bohrium' },
+    { key: '1', content: 'Neptunium'},
+    { key: '2', content: 'Plutonium' },
+    { key: '3', content: 'Americium' },
+    { key: '4', content: 'Curium' },
+    { key: '5', content: 'Berkelium' },
+    { key: '6', content: 'Californium' },
+    { key: '7', content: 'Einsteinium' },
+    { key: '8', content: 'Fermium' },
+    { key: '9', content: 'Mendelevium' },
+    { key: '10', content: 'Nobelium' },
+    { key: '11', content: 'Lawrencium' },
+    { key: '12', content: 'Rutherfordium' },
+    { key: '13', content: 'Dubnium' },
+    { key: '14', content: 'Seaborgium' },
+    { key: '15', content: 'Bohrium' },
 ];
 
 export const groups = [
     {
         label: 'Группа №1',
         options: [
-            { value: '1', text: 'Neptunium' },
-            { value: '2', text: 'Plutonium' },
-            { value: '3', text: 'Americium' },
-            { value: '4', text: 'Curium' },
+            { key: '1', content: 'Neptunium' },
+            { key: '2', content: 'Plutonium' },
+            { key: '3', content: 'Americium' },
+            { key: '4', content: 'Curium' },
         ]
     },
     {
         label: 'Группа №2',
         options: [
-            { value: '5', text: 'Berkelium' },
-            { value: '6', text: 'Californium' },
-            { value: '7', text: 'Einsteinium' },
-            { value: '8', text: 'Fermium' },
-            { value: '9', text: 'Mendelevium' },
-            { value: '10', text: 'Nobelium' },
+            { key: '5', content: 'Berkelium' },
+            { key: '6', content: 'Californium' },
+            { key: '7', content: 'Einsteinium' },
+            { key: '8', content: 'Fermium' },
+            { key: '9', content: 'Mendelevium' },
+            { key: '10', content: 'Nobelium' },
         ]
     },
     {
         label: 'Группа №3',
         options: [
-            { value: '11', text: 'Lawrencium' },
-            { value: '12', text: 'Rutherfordium' },
-            { value: '13', text: 'Dubnium' },
-            { value: '14', text: 'Seaborgium' },
-            { value: '15', text: 'Bohrium' },
+            { key: '11', content: 'Lawrencium' },
+            { key: '12', content: 'Rutherfordium' },
+            { key: '13', content: 'Dubnium' },
+            { key: '14', content: 'Seaborgium' },
+            { key: '15', content: 'Bohrium' },
         ]
     },
 ];
@@ -72,12 +72,12 @@ export const groups = [
 export const optionsWithHtml = options.map(option => {
     return {
         ...option,
-        content: (<span style={{ fontWeight: 'bold' }}>{option.text}</span>),
+        content: (<span style={{ fontWeight: 'bold' }}>{option.content}</span>),
     };
 });
 
 export const renderUppercased = (options) => {
-    return options.map(option => option.text.toUpperCase()).join(', ');
+    return options.map(option => option.content.toUpperCase()).join(', ');
 };
 
 
@@ -177,8 +177,8 @@ import { Select } from '@alfalab/core-components-select';
     <div style={{ height: 180, width: 300 }}>
         {React.createElement(() => {
             const [selected, setSelected] = React.useState([options[8].value, options[9].value]);
-            const handleChange = ({ selected }) => {
-                setSelected(selected);
+            const handleChange = ({ selectedMultiple }) => {
+                setSelected(selectedMultiple.map(option => option.key));
             };
             return (
                 <Select
@@ -203,9 +203,9 @@ import { Select } from '@alfalab/core-components-select';
     <div style={{ height: 180, width: 300 }}>
         {React.createElement(() => {
             const options = [
-                { value: 'value1', text: 'Neptunium'},
-                { value: 'value2', text: 'Plutonium' },
-                { value: 'value3', text: 'Americium' },
+                { key: '1', content: 'Neptunium' },
+                { key: '2', content: 'Plutonium' },
+                { key: '3', content: 'Americium' },
             ];
             const [serialized, setSerialized] = React.useState();
             const onSubmit = (event) => {
@@ -240,9 +240,9 @@ import { Select } from '@alfalab/core-components-select';
 <Preview>
     <div style={{ height: 180, width: 480 }}>
         {React.createElement(() => {
-            const [selected, setSelected] = React.useState([]);
+            const [selected, setSelected] = React.useState(null);
             const handleChange = ({ selected }) => {
-                setSelected(selected);
+                setSelected(selected ? selected.key : null);
             };
             const Card = ({ name, balance }) => (
                 <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -260,10 +260,10 @@ import { Select } from '@alfalab/core-components-select';
                     onChange={handleChange}
                     size='l'
                     options={[
-                        { value: '1', text: 'Account1', content: <Card name='Account1 Name ··0000' balance='100 000,00 ₽' /> },
-                        { value: '2', text: 'Account2', content: <Card name='Account2 Name ··0000' balance='150 000,00 ₽' /> },
-                        { value: '3', text: 'Account3', content: <Card name='Account3 Name ··0000' balance='230 000,00 ₽' /> },
-                        { value: '4', text: 'Account4', content: <Card name='Account4 Name ··0000' balance='12 000,00 ₽' /> },
+                        { key: 'Account1', content: <Card name='Account1 Name ··0000' balance='100 000,00 ₽' /> },
+                        { key: 'Account2', content: <Card name='Account2 Name ··0000' balance='150 000,00 ₽' /> },
+                        { key: 'Account3', content: <Card name='Account3 Name ··0000' balance='230 000,00 ₽' /> },
+                        { key: 'Account4', content: <Card name='Account4 Name ··0000' balance='12 000,00 ₽' /> },
                     ]}
                     multiple={false}
                     placeholder='Выберите карту'
@@ -279,18 +279,13 @@ import { Select } from '@alfalab/core-components-select';
 <Preview>
     <div style={{ height: 180 }}>
         {React.createElement(() => {
-            const OptionWithIcon = ({ text, value }) => (
-                <span style={{ display: 'flex' }} key={value}>
+            const OptionWithIcon = ({ content }) => (
+                <span style={{ display: 'flex' }} key={content}>
                     <Icon />
-                    {text}
+                    {content.toUpperCase()}
                 </span>
             );
-            const renderOption = React.forwardRef((props, ref) => (
-                <Option {...props} ref={ref}>
-                    <OptionWithIcon key={props.option.value} {...props.option} />
-                </Option>
-            ));
-            const valueRenderer = (options) => options.map(OptionWithIcon);
+            const valueRenderer = ({ selected }) => <OptionWithIcon {...selected}/>;
             return (
                 <Select
                     options={options}
@@ -298,7 +293,6 @@ import { Select } from '@alfalab/core-components-select';
                     fieldProps={{
                         valueRenderer
                     }}
-                    Option={renderOption}
                 />
             );
         })}
@@ -314,7 +308,7 @@ import { Select } from '@alfalab/core-components-select';
                 <Col>
                     {React.createElement(() => {
                         const BoldOption = React.forwardRef((props, ref) => (
-                            <Option {...props} ref={ref}><b>{props.option.text}</b></Option>
+                            <Option {...props} ref={ref}><b>{props.option.content}</b></Option>
                         ));
                         return (
                             <Select
@@ -329,20 +323,18 @@ import { Select } from '@alfalab/core-components-select';
                     <Select
                         options={options}
                         label='With addons'
-                        Field={(props) => <Field {...props} leftAddons={props.selectedItems.length > 0 && <Icon/>} />}
+                        Field={(props) => <Field {...props} leftAddons={props.selected && <Icon/>} />}
                     />
                 </Col>
                 <Col>
                     <Select
                         options={options}
                         allowUnselect={true}
-                        Field={(props) => {
-                            return (
-                                <Button {...props.innerProps}>
-                                    {props.selectedItems.length ? props.selectedItems[0].text : 'Pick'}
-                                </Button>
-                            );
-                        }}
+                        Field={({ selected, innerProps, ...restProps }) => (
+                            <Button {...innerProps}>
+                                {selected ? selected.content : 'Pick'}
+                            </Button>
+                        )}
                     />
                 </Col>
             </Row>
@@ -358,15 +350,15 @@ import { Select } from '@alfalab/core-components-select';
 const groups = [{
     label: 'Группа №1',
     options: [
-        { value: '1', text: 'Neptunium' },
-        { value: '2', text: 'Plutonium' },
+        { key: '1', content: 'Neptunium' },
+        { key: '2', content: 'Plutonium' },
     ]
 },
 {
     label: 'Группа №2',
     options: [
-        { value: '3', text: 'Berkelium' },
-        { value: '4', text: 'Californium' },
+        { key: '3', content: 'Berkelium' },
+        { key: '4', content: 'Californium' },
     ]
 }]
 ```
@@ -413,8 +405,8 @@ const groups = [{
                                 Math.round(Math.random() * 10),
                             );
                             return {
-                                value: index,
-                                text: `${index}. ${variableSizeText}`,
+                                key: index,
+                                content: `${index}. ${variableSizeText}`,
                             };
                         });
                         return (

--- a/packages/select/src/Component.stories.mdx
+++ b/packages/select/src/Component.stories.mdx
@@ -12,6 +12,7 @@ import { OptionsList } from './components/options-list';
 import { VirtualOptionsList } from './components/virtual-options-list';
 import { Optgroup } from './components/optgroup';
 import { Option } from './components/option';
+import { Button } from '../../button/src';
 import { joinOptions } from './utils';
 import { name, version } from '../package.json';
 
@@ -329,6 +330,19 @@ import { Select } from '@alfalab/core-components-select';
                         options={options}
                         label='With addons'
                         Field={(props) => <Field {...props} leftAddons={props.selectedItems.length > 0 && <Icon/>} />}
+                    />
+                </Col>
+                <Col>
+                    <Select
+                        options={options}
+                        allowUnselect={true}
+                        Field={(props) => {
+                            return (
+                                <Button {...props.innerProps}>
+                                    {props.selectedItems.length ? props.selectedItems[0].text : 'Pick'}
+                                </Button>
+                            );
+                        }}
                     />
                 </Col>
             </Row>

--- a/packages/select/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/select/src/__snapshots__/Component.test.tsx.snap
@@ -12,75 +12,16 @@ Object {
         class="component"
         role="combobox"
       >
-        <div
-          class="fieldWrapper"
-          role="button"
-        >
-          <div>
+        <div>
+          <div
+            class="component s hasRightAddons component s"
+          >
             <div
               aria-controls="downshift-1-menu"
               aria-labelledby="downshift-1-label"
-              class="component s hasRightAddons component s"
+              class="inner"
               id="downshift-0-input"
               tabindex="0"
-            >
-              <div
-                class="inner"
-              >
-                <div
-                  class="inputWrapper"
-                >
-                  <div
-                    class="input"
-                  >
-                    <div
-                      class="contentWrapper"
-                    />
-                  </div>
-                </div>
-                <div
-                  class="addons rightAddons"
-                >
-                  <span
-                    class="arrow"
-                  />
-                </div>
-              </div>
-              
-            </div>
-          </div>
-        </div>
-        <div
-          aria-labelledby="downshift-1-label"
-          class="listWrapper"
-          id="downshift-1-menu"
-          role="listbox"
-        />
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-owns="downshift-1-menu"
-      class="component"
-      role="combobox"
-    >
-      <div
-        class="fieldWrapper"
-        role="button"
-      >
-        <div>
-          <div
-            aria-controls="downshift-1-menu"
-            aria-labelledby="downshift-1-label"
-            class="component s hasRightAddons component s"
-            id="downshift-0-input"
-            tabindex="0"
-          >
-            <div
-              class="inner"
             >
               <div
                 class="inputWrapper"
@@ -103,6 +44,55 @@ Object {
             </div>
             
           </div>
+        </div>
+        <div
+          aria-labelledby="downshift-1-label"
+          class="listWrapper"
+          id="downshift-1-menu"
+          role="listbox"
+        />
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-owns="downshift-1-menu"
+      class="component"
+      role="combobox"
+    >
+      <div>
+        <div
+          class="component s hasRightAddons component s"
+        >
+          <div
+            aria-controls="downshift-1-menu"
+            aria-labelledby="downshift-1-label"
+            class="inner"
+            id="downshift-0-input"
+            tabindex="0"
+          >
+            <div
+              class="inputWrapper"
+            >
+              <div
+                class="input"
+              >
+                <div
+                  class="contentWrapper"
+                />
+              </div>
+            </div>
+            <div
+              class="addons rightAddons"
+            >
+              <span
+                class="arrow"
+              />
+            </div>
+          </div>
+          
         </div>
       </div>
       <div

--- a/packages/select/src/__snapshots__/utils.test.tsx.snap
+++ b/packages/select/src/__snapshots__/utils.test.tsx.snap
@@ -31,3 +31,17 @@ Array [
   </b>,
 ]
 `;
+
+exports[`joinOptions should match snapshots 3`] = `
+Array [
+  "Neptunium",
+]
+`;
+
+exports[`joinOptions should match snapshots 4`] = `
+Array [
+  <b>
+    Neptunium
+  </b>,
+]
+`;

--- a/packages/select/src/components/arrow/index.module.css
+++ b/packages/select/src/components/arrow/index.module.css
@@ -1,4 +1,5 @@
 @import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .arrow {
     display: block;

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -47,8 +47,7 @@ export const BaseSelect = forwardRef(
 
         const getPortalContainer = () => optionsListRef.current as HTMLDivElement;
 
-        const itemToString = (option: OptionShape) =>
-            option ? option.text || option.value.toString() : '';
+        const itemToString = (option: OptionShape) => (option ? option.key : '');
 
         const flatOptions = useMemo(
             () =>
@@ -67,17 +66,17 @@ export const BaseSelect = forwardRef(
                     const { selectedItems = [] } = changes;
 
                     onChange({
-                        selectedOptions: selectedItems,
-                        selected: selectedItems.map(item => item.value),
+                        selectedMultiple: selectedItems,
+                        selected: selectedItems.length ? selectedItems[0] : null,
                         name,
                     });
                 }
             },
         };
 
-        if (selected) {
+        if (selected !== undefined) {
             useMultipleSelectionProps.selectedItems = flatOptions.filter(option =>
-                selected.includes(option.value),
+                Array.isArray(selected) ? selected.includes(option.key) : selected === option.key,
             );
         }
 
@@ -202,7 +201,7 @@ export const BaseSelect = forwardRef(
                         item: option,
                         disabled: option.disabled,
                     })}
-                    key={option.value}
+                    key={option.key}
                     index={index}
                     option={option}
                     size={size}
@@ -218,15 +217,15 @@ export const BaseSelect = forwardRef(
         const renderValue = useCallback(
             () =>
                 selectedItems.map(option => (
-                    <input type='hidden' name={name} value={option.value} key={option.value} />
+                    <input type='hidden' name={name} value={option.key} key={option.key} />
                 )),
             [selectedItems, name],
         );
 
         const renderNativeSelect = useCallback(() => {
             const value = multiple
-                ? selectedItems.map(option => option.value)
-                : (selectedItems[0] || {}).value;
+                ? selectedItems.map(option => option.key)
+                : (selectedItems[0] || {}).key;
 
             return (
                 <NativeSelect
@@ -252,7 +251,8 @@ export const BaseSelect = forwardRef(
                 {nativeSelect && renderNativeSelect()}
 
                 <Field
-                    selectedItems={selectedItems}
+                    selectedMultiple={selectedItems}
+                    selected={selectedItems[0]}
                     multiple={multiple}
                     open={open}
                     disabled={disabled}

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -103,6 +103,7 @@ export const BaseSelect = forwardRef(
             circularNavigation,
             items: flatOptions,
             itemToString,
+            defaultHighlightedIndex: selectedItems.length === 0 ? 0 : undefined,
             onIsOpenChange: changes => {
                 if (onOpen) {
                     onOpen({

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -268,7 +268,7 @@ export const BaseSelect = forwardRef(
                         onFocus: disabled ? undefined : handleFieldFocus,
                         onKeyDown: disabled ? undefined : handleFieldKeyDown,
                         onClick: disabled ? undefined : handleFieldClick,
-                        tabIndex: nativeSelect ? -1 : 0,
+                        tabIndex: nativeSelect || disabled ? -1 : 0,
                         ref: mergeRefs([inputProps.ref]),
                         id: inputProps.id,
                         'aria-labelledby': inputProps['aria-labelledby'],

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo, useCallback, KeyboardEvent, MouseEvent, forwardRef } from 'react';
+import React, { useRef, useMemo, useCallback, MouseEvent, forwardRef, KeyboardEvent } from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 import { Popover } from '@alfalab/core-components-popover';
@@ -91,7 +91,6 @@ export const BaseSelect = forwardRef(
 
         const {
             isOpen: open,
-            getToggleButtonProps,
             getMenuProps,
             getInputProps,
             getItemProps,
@@ -99,7 +98,6 @@ export const BaseSelect = forwardRef(
             getLabelProps,
             highlightedIndex,
             toggleMenu,
-            closeMenu,
             openMenu,
         } = useCombobox<OptionShape>({
             id,
@@ -156,15 +154,14 @@ export const BaseSelect = forwardRef(
 
         const menuProps = getMenuProps(nativeSelect ? {} : { ref: optionsListRef });
         const inputProps = getInputProps(getDropdownProps({ ref: mergeRefs([ref, fieldRef]) }));
-        const toggleButtonProps = getToggleButtonProps();
 
-        const handleFieldWrapperFocus = () => {
+        const handleFieldFocus = () => {
             if (autocomplete && !open) {
                 openMenu();
             }
         };
 
-        const handleFieldWrapperKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+        const handleFieldKeyDown = (event: KeyboardEvent<HTMLDivElement | HTMLInputElement>) => {
             inputProps.onKeyDown(event);
 
             if (autocomplete && !open && event.key.length === 1) {
@@ -179,24 +176,8 @@ export const BaseSelect = forwardRef(
             }
         };
 
-        const handleFieldWrapperMouseDown = () => {
-            if (open) {
-                closeMenu();
-            } else {
-                openMenu();
-            }
-
-            if (!autocomplete && fieldRef.current) fieldRef.current.focus();
-        };
-
-        const fieldWrapperProps = {
-            className: styles.fieldWrapper,
-            role: 'button',
-            ref: toggleButtonProps.ref,
-            onBlur: inputProps.onBlur,
-            onFocus: disabled ? undefined : handleFieldWrapperFocus,
-            onKeyDown: disabled ? undefined : handleFieldWrapperKeyDown,
-            onMouseDown: disabled ? undefined : handleFieldWrapperMouseDown,
+        const handleFieldClick = () => {
+            toggleMenu();
         };
 
         const handleNativeSelectChange = useCallback(
@@ -268,33 +249,35 @@ export const BaseSelect = forwardRef(
                 })}
                 data-test-id={dataTestId}
             >
-                <div {...fieldWrapperProps}>
-                    {nativeSelect && renderNativeSelect()}
+                {nativeSelect && renderNativeSelect()}
 
-                    <Field
-                        selectedItems={selectedItems}
-                        multiple={multiple}
-                        open={open}
-                        disabled={disabled}
-                        size={size}
-                        placeholder={placeholder}
-                        label={label && <span {...getLabelProps()}>{label}</span>}
-                        Arrow={Arrow && <Arrow open={open} />}
-                        error={error}
-                        hint={hint}
-                        innerProps={{
-                            tabIndex: nativeSelect ? -1 : 0,
-                            ref: inputProps.ref,
-                            id: inputProps.id,
-                            'aria-labelledby': inputProps['aria-labelledby'],
-                            'aria-controls': inputProps['aria-controls'],
-                            'aria-autocomplete': autocomplete
-                                ? inputProps['aria-autocomplete']
-                                : undefined,
-                        }}
-                        {...fieldProps}
-                    />
-                </div>
+                <Field
+                    selectedItems={selectedItems}
+                    multiple={multiple}
+                    open={open}
+                    disabled={disabled}
+                    size={size}
+                    placeholder={placeholder}
+                    label={label && <span {...getLabelProps()}>{label}</span>}
+                    Arrow={Arrow && <Arrow open={open} />}
+                    error={error}
+                    hint={hint}
+                    innerProps={{
+                        onBlur: inputProps.onBlur,
+                        onFocus: disabled ? undefined : handleFieldFocus,
+                        onKeyDown: disabled ? undefined : handleFieldKeyDown,
+                        onClick: disabled ? undefined : handleFieldClick,
+                        tabIndex: nativeSelect ? -1 : 0,
+                        ref: mergeRefs([inputProps.ref]),
+                        id: inputProps.id,
+                        'aria-labelledby': inputProps['aria-labelledby'],
+                        'aria-controls': inputProps['aria-controls'],
+                        'aria-autocomplete': autocomplete
+                            ? inputProps['aria-autocomplete']
+                            : undefined,
+                    }}
+                    {...fieldProps}
+                />
 
                 {name && !nativeSelect && renderValue()}
 

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -1,4 +1,12 @@
-import React, { useRef, useMemo, useCallback, MouseEvent, forwardRef, KeyboardEvent } from 'react';
+import React, {
+    useRef,
+    useMemo,
+    useCallback,
+    MouseEvent,
+    forwardRef,
+    KeyboardEvent,
+    FocusEvent,
+} from 'react';
 import mergeRefs from 'react-merge-refs';
 import cn from 'classnames';
 import { Popover } from '@alfalab/core-components-popover';
@@ -34,6 +42,8 @@ export const BaseSelect = forwardRef(
             fieldProps = {},
             onChange,
             onOpen,
+            onFocus,
+            onBlur,
             Arrow,
             Field = () => null,
             OptionsList = () => null,
@@ -155,10 +165,18 @@ export const BaseSelect = forwardRef(
         const menuProps = getMenuProps(nativeSelect ? {} : { ref: optionsListRef });
         const inputProps = getInputProps(getDropdownProps({ ref: mergeRefs([ref, fieldRef]) }));
 
-        const handleFieldFocus = () => {
+        const handleFieldFocus = (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => {
+            if (onFocus) onFocus(event);
+
             if (autocomplete && !open) {
                 openMenu();
             }
+        };
+
+        const handleFieldBlur = (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => {
+            if (onBlur) onBlur(event);
+
+            inputProps.onBlur(event);
         };
 
         const handleFieldKeyDown = (event: KeyboardEvent<HTMLDivElement | HTMLInputElement>) => {
@@ -264,7 +282,7 @@ export const BaseSelect = forwardRef(
                     error={error}
                     hint={hint}
                     innerProps={{
-                        onBlur: inputProps.onBlur,
+                        onBlur: handleFieldBlur,
                         onFocus: disabled ? undefined : handleFieldFocus,
                         onKeyDown: disabled ? undefined : handleFieldKeyDown,
                         onClick: disabled ? undefined : handleFieldClick,

--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -9,12 +9,11 @@
 
 .popover {
     min-width: 100%;
+    padding-top: var(--select-popover-offset);
+    padding-bottom: var(--select-popover-offset);
+    box-shadow: none;
     border: none;
-    box-shadow: var(--select-popover-box-shadow);
-    border-radius: var(--select-popover-border-radius);
-    overflow: hidden;
-    margin-top: var(--select-popover-offset);
-    margin-bottom: var(--select-popover-offset);
+    border-radius: 0;
 }
 
 .listWrapper {

--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -7,11 +7,6 @@
     position: relative;
 }
 
-.fieldWrapper {
-    position: relative;
-    outline: none;
-}
-
 .popover {
     min-width: 100%;
     border: none;

--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -13,6 +13,7 @@
     padding-bottom: var(--select-popover-offset);
     box-shadow: none;
     border: none;
+    background: transparent;
     border-radius: 0;
 }
 

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -10,6 +10,9 @@ import styles from './index.module.css';
 export const Field = ({
     size = 'm',
     open,
+    multiple,
+    error,
+    hint,
     disabled,
     label,
     placeholder,
@@ -17,7 +20,7 @@ export const Field = ({
     rightAddons,
     valueRenderer = joinOptions,
     Arrow,
-    innerProps = {},
+    innerProps,
     ...restProps
 }: BaseFieldProps & FormControlProps) => {
     const [focused, setFocused] = useState(false);
@@ -45,14 +48,14 @@ export const Field = ({
                 disabled={disabled}
                 filled={filled || !!placeholder}
                 label={label}
+                error={error}
+                hint={hint}
                 rightAddons={
                     <React.Fragment>
                         {rightAddons}
                         {Arrow}
                     </React.Fragment>
                 }
-                onBlur={handleBlur}
-                onFocus={handleFocus}
                 {...innerProps}
                 {...restProps}
             >

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -16,7 +16,8 @@ export const Field = ({
     disabled,
     label,
     placeholder,
-    selectedItems = [],
+    selectedMultiple = [],
+    selected,
     rightAddons,
     valueRenderer = joinOptions,
     Arrow,
@@ -29,7 +30,7 @@ export const Field = ({
 
     const [focusVisible] = useFocus(wrapperRef, 'keyboard');
 
-    const filled = selectedItems.length > 0;
+    const filled = selectedMultiple.length > 0;
 
     const handleFocus = useCallback(() => setFocused(true), []);
     const handleBlur = useCallback(() => setFocused(false), []);
@@ -63,7 +64,11 @@ export const Field = ({
                     {placeholder && !filled && (
                         <span className={styles.placeholder}>{placeholder}</span>
                     )}
-                    {filled && <div className={styles.value}>{valueRenderer(selectedItems)}</div>}
+                    {filled && (
+                        <div className={styles.value}>
+                            {valueRenderer({ selected, selectedMultiple })}
+                        </div>
+                    )}
                 </div>
             </FormControl>
         </div>

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -60,8 +60,8 @@ export const Field = ({
                         </React.Fragment>
                     )
                 }
-                {...innerProps}
                 {...restProps}
+                {...innerProps}
             >
                 <div className={styles.contentWrapper}>
                     {placeholder && !filled && (

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -22,6 +22,7 @@ export const Field = ({
     valueRenderer = joinOptions,
     Arrow,
     innerProps,
+    className,
     ...restProps
 }: BaseFieldProps & FormControlProps) => {
     const [focused, setFocused] = useState(false);
@@ -38,7 +39,7 @@ export const Field = ({
     return (
         <div ref={wrapperRef} onFocus={handleFocus} onBlur={handleBlur}>
             <FormControl
-                className={cn(styles.component, styles[size], {
+                className={cn(styles.component, className, styles[size], {
                     [styles.open]: open,
                     [styles.hasLabel]: label,
                     [styles.disabled]: disabled,

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -53,10 +53,12 @@ export const Field = ({
                 error={error}
                 hint={hint}
                 rightAddons={
-                    <React.Fragment>
-                        {rightAddons}
-                        {Arrow}
-                    </React.Fragment>
+                    (Arrow || rightAddons) && (
+                        <React.Fragment>
+                            {rightAddons}
+                            {Arrow}
+                        </React.Fragment>
+                    )
                 }
                 {...innerProps}
                 {...restProps}

--- a/packages/select/src/components/field/index.module.css
+++ b/packages/select/src/components/field/index.module.css
@@ -3,7 +3,10 @@
 .component {
     width: 100%;
     outline: none;
-    cursor: pointer;
+
+    & > div:first-child {
+        cursor: pointer;
+    }
 }
 
 /* TODO: Заюзать переменные из инпута */
@@ -30,7 +33,7 @@
     text-align: left;
 }
 
-.disabled {
+.disabled > div:first-child {
     cursor: default;
 }
 

--- a/packages/select/src/components/field/index.module.css
+++ b/packages/select/src/components/field/index.module.css
@@ -25,6 +25,7 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+    width: 100%;
 }
 
 .value {

--- a/packages/select/src/components/field/index.module.css
+++ b/packages/select/src/components/field/index.module.css
@@ -1,4 +1,5 @@
 @import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .component {
     width: 100%;

--- a/packages/select/src/components/native-select/Component.tsx
+++ b/packages/select/src/components/native-select/Component.tsx
@@ -14,16 +14,16 @@ export type NativeSelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
     value: string | string[];
 };
 
-const Option = ({ value, text, disabled }: OptionShape) => (
-    <option value={value} disabled={disabled}>
-        {text || value}
+const Option = ({ option }: { option: OptionShape }) => (
+    <option value={option.key} disabled={option.disabled}>
+        {typeof option.content === 'string' ? option.content : option.key}
     </option>
 );
 
 const Group = ({ label, options }: GroupShape) => (
     <optgroup label={label}>
         {options.map(option => (
-            <Option {...option} key={option.value} />
+            <Option option={option} key={option.key} />
         ))}
     </optgroup>
 );
@@ -50,7 +50,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
                     isGroup(option) ? (
                         <Group {...option} key={option.label} />
                     ) : (
-                        <Option {...option} key={option.value} />
+                        <Option option={option} key={option.key} />
                     ),
                 )}
             </select>

--- a/packages/select/src/components/optgroup/index.module.css
+++ b/packages/select/src/components/optgroup/index.module.css
@@ -1,4 +1,5 @@
 @import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .optgroup {
     position: relative;

--- a/packages/select/src/components/option/Component.tsx
+++ b/packages/select/src/components/option/Component.tsx
@@ -30,9 +30,7 @@ export const Option = forwardRef<HTMLDivElement, OptionProps>(
             })}
         >
             {Checkmark && <Checkmark selected={selected} />}
-            <div className={styles.content}>
-                {children || option.content || option.text || option.value}
-            </div>
+            <div className={styles.content}>{children || option.content || option.key}</div>
         </div>
     ),
 );

--- a/packages/select/src/components/options-list/index.module.css
+++ b/packages/select/src/components/options-list/index.module.css
@@ -6,6 +6,8 @@
     outline: none;
     padding-top: var(--select-options-list-top-padding);
     padding-bottom: var(--select-options-list-bottom-padding);
+    box-shadow: var(--select-popover-box-shadow);
+    border-radius: var(--select-popover-border-radius);
     box-sizing: border-box;
 }
 

--- a/packages/select/src/components/options-list/index.module.css
+++ b/packages/select/src/components/options-list/index.module.css
@@ -1,4 +1,5 @@
 @import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .optionsList {
     overflow: auto;

--- a/packages/select/src/components/options-list/index.module.css
+++ b/packages/select/src/components/options-list/index.module.css
@@ -8,6 +8,7 @@
     padding-bottom: var(--select-options-list-bottom-padding);
     box-shadow: var(--select-popover-box-shadow);
     border-radius: var(--select-popover-border-radius);
+    background: var(--select-option-background);
     box-sizing: border-box;
 }
 

--- a/packages/select/src/components/virtual-options-list/index.module.css
+++ b/packages/select/src/components/virtual-options-list/index.module.css
@@ -1,4 +1,5 @@
 @import '../../../../themes/src/default.css';
+@import '../../vars.css';
 
 .virtualOptionsList {
     overflow: auto;

--- a/packages/select/src/components/virtual-options-list/index.module.css
+++ b/packages/select/src/components/virtual-options-list/index.module.css
@@ -6,6 +6,8 @@
     outline: none;
     padding-top: var(--select-options-list-top-padding);
     padding-bottom: var(--select-options-list-bottom-padding);
+    box-shadow: var(--select-popover-box-shadow);
+    border-radius: var(--select-popover-border-radius);
     box-sizing: border-box;
     position: relative;
 }

--- a/packages/select/src/components/virtual-options-list/index.module.css
+++ b/packages/select/src/components/virtual-options-list/index.module.css
@@ -8,6 +8,7 @@
     padding-bottom: var(--select-options-list-bottom-padding);
     box-shadow: var(--select-popover-box-shadow);
     border-radius: var(--select-popover-border-radius);
+    background: var(--select-option-background);
     box-sizing: border-box;
     position: relative;
 }

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -10,17 +10,12 @@ import {
 
 export type OptionShape = {
     /**
-     * Значение выбранного пункта (например, для отправки на сервер)
-     */
-    value: string | number;
-
-    /**
      * Текстовое представление пункта
      */
-    text: string;
+    key: string;
 
     /**
-     * Контент, который будет отрендерен в выпадающем списке и в поле при выборе
+     * Контент, который будет отрисован в выпадающем списке и в поле при выборе
      */
     content?: ReactNode;
 
@@ -28,6 +23,11 @@ export type OptionShape = {
      * Блокирует данный пункт для выбора
      */
     disabled?: boolean;
+
+    /**
+     * Дополнительные данные
+     */
+    value?: unknown;
 };
 
 export type GroupShape = {
@@ -131,7 +131,7 @@ export type BaseSelectProps = {
     /**
      * Список value выбранных пунктов (controlled-селект)
      */
-    selected?: Array<OptionShape['value']>;
+    selected?: string[] | string | null;
 
     /**
      * Рендерит нативный селект вместо выпадающего меню. (на десктопе использовать только с multiple=false)
@@ -177,8 +177,8 @@ export type BaseSelectProps = {
      * Обработчик выбора
      */
     onChange?: (payload: {
-        selected?: Array<OptionShape['value']>;
-        selectedOptions?: OptionShape[];
+        selected: OptionShape | null;
+        selectedMultiple: OptionShape[];
         name?: string;
     }) => void;
 
@@ -195,9 +195,14 @@ export type FieldProps = {
     size?: 's' | 'm' | 'l';
 
     /**
+     * Выбранный пункт
+     */
+    selected?: OptionShape;
+
+    /**
      * Список выбранных пунктов
      */
-    selectedItems?: OptionShape[];
+    selectedMultiple?: OptionShape[];
 
     /**
      * Флаг, можно ли выбрать несколько значений
@@ -242,7 +247,13 @@ export type FieldProps = {
     /**
      * Кастомный рендер выбранного пункта
      */
-    valueRenderer?: (options: OptionShape[]) => ReactNode;
+    valueRenderer?: ({
+        selected,
+        selectedMultiple,
+    }: {
+        selected?: OptionShape;
+        selectedMultiple: OptionShape[];
+    }) => ReactNode;
 
     /**
      * Внутренние свойства, которые должны быть установлены компоненту.

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -27,7 +27,8 @@ export type OptionShape = {
     /**
      * Дополнительные данные
      */
-    value?: unknown;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    value?: any;
 };
 
 export type GroupShape = {

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -187,6 +187,16 @@ export type BaseSelectProps = {
      * Обработчик открытия\закрытия селекта
      */
     onOpen?: (payload: { open?: boolean; name?: string }) => void;
+
+    /**
+     * Обработчик фокуса поля
+     */
+    onBlur?: (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => void;
+
+    /**
+     * Обработчик блюра поля
+     */
+    onFocus?: (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => void;
 };
 
 export type FieldProps = {

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -147,7 +147,7 @@ export type BaseSelectProps = {
     /**
      * Компонент стрелки
      */
-    Arrow?: FC<ArrowProps>;
+    Arrow?: FC<ArrowProps> | null | false;
 
     /**
      * Компонент поля

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -1,4 +1,12 @@
-import { ReactNode, FC, HTMLAttributes, RefAttributes, AriaAttributes } from 'react';
+import {
+    ReactNode,
+    FC,
+    RefAttributes,
+    AriaAttributes,
+    FocusEvent,
+    KeyboardEvent,
+    MouseEvent,
+} from 'react';
 
 export type OptionShape = {
     /**
@@ -239,8 +247,14 @@ export type FieldProps = {
     /**
      * Внутренние свойства, которые должны быть установлены компоненту.
      */
-    innerProps?: Pick<HTMLAttributes<HTMLElement>, 'tabIndex' | 'id'> &
-        RefAttributes<HTMLDivElement | HTMLInputElement> &
+    innerProps: {
+        onBlur?: (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => void;
+        onFocus?: (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => void;
+        onKeyDown?: (event: KeyboardEvent<HTMLDivElement | HTMLInputElement>) => void;
+        onClick?: (event: MouseEvent<HTMLDivElement | HTMLInputElement>) => void;
+        tabIndex: number;
+        id: string;
+    } & RefAttributes<HTMLDivElement | HTMLInputElement> &
         AriaAttributes;
 };
 

--- a/packages/select/src/utils.test.tsx
+++ b/packages/select/src/utils.test.tsx
@@ -4,21 +4,23 @@ import { OptionShape } from './typings';
 
 describe('joinOptions', () => {
     const textOptions: OptionShape[] = [
-        { value: '1', text: 'Neptunium' },
-        { value: '2', text: 'Plutonium' },
-        { value: '3', text: 'Americium' },
-        { value: '4', text: 'Curium' },
+        { key: '1', content: 'Neptunium' },
+        { key: '2', content: 'Plutonium' },
+        { key: '3', content: 'Americium' },
+        { key: '4', content: 'Curium' },
     ];
 
     const htmlOptions: OptionShape[] = [
-        { value: '1', text: 'Neptunium', content: <b>Neptunium</b> },
-        { value: '2', text: 'Plutonium', content: <b>Plutonium</b> },
-        { value: '3', text: 'Americium', content: <b>Americium</b> },
-        { value: '4', text: 'Curium', content: <b>Curium</b> },
+        { key: 'Neptunium', content: <b>Neptunium</b> },
+        { key: 'Plutonium', content: <b>Plutonium</b> },
+        { key: 'Americium', content: <b>Americium</b> },
+        { key: 'Curium', content: <b>Curium</b> },
     ];
 
     it('should match snapshots', () => {
-        expect(joinOptions(textOptions)).toMatchSnapshot();
-        expect(joinOptions(htmlOptions)).toMatchSnapshot();
+        expect(joinOptions({ selectedMultiple: textOptions })).toMatchSnapshot();
+        expect(joinOptions({ selectedMultiple: htmlOptions })).toMatchSnapshot();
+        expect(joinOptions({ selected: textOptions[0] })).toMatchSnapshot();
+        expect(joinOptions({ selected: htmlOptions[0] })).toMatchSnapshot();
     });
 });

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -4,17 +4,26 @@ import { OptionShape, GroupShape } from './typings';
 export const isGroup = (item: OptionShape | GroupShape): item is GroupShape =>
     Object.prototype.hasOwnProperty.call(item, 'options');
 
-export const joinOptions = (options: OptionShape[]) =>
-    options.reduce((acc: Array<ReactNode | string>, option: OptionShape, index: number) => {
+export const joinOptions = ({
+    selected,
+    selectedMultiple,
+}: {
+    selected?: OptionShape;
+    selectedMultiple?: OptionShape[];
+}) => {
+    const options = selectedMultiple || (selected ? [selected] : []);
+
+    return options.reduce((acc: Array<ReactNode | string>, option: OptionShape, index: number) => {
         if (isValidElement(option.content)) {
-            acc.push(cloneElement(option.content, { key: option.value }));
+            acc.push(cloneElement(option.content, { key: option.key }));
         } else {
-            acc.push(option.text);
+            acc.push(option.content);
         }
 
         if (index < options.length - 1) acc.push(', ');
         return acc;
     }, []);
+};
 
 // TODO: перенести
 export function usePrevious<T>(value: T) {


### PR DESCRIPTION
## Изменения

1. Понадобилось вешать `onClick` и `onMouseDown` на инпут, но не на сам `<input>`, а не весь контрол. Поэтому перенес ...restProps в `FormControl` и добавил явные обработчики в `Input`

2. Небольшой рефакторинг селекта и автокомплита, убрал лишний код и немного упростил. Надеюсь, что это последний раз 🧠 💥 

3. После интеграции в клик, появилось желание изменить структуру данных и упростить работу с компонентом.
Предлагаю сделать следующие изменения:

    3.1. Данные принимать в таком виде:
    ```tsx
    export type OptionShape = {
        /**
        * Текстовое представление пункта. Единственное необходимое поле
        */
        key: string;

        /**
        * Контент, который будет отрисован в выпадающем списке и в поле при выборе
        */
        content?: ReactNode;

        /**
        * Блокирует данный пункт для выбора
        */
        disabled?: boolean;

        /**
        * Дополнительные данные
        */
        value?: any;
    };
    ```

    3.2. Заменить обработчик выбора, чтобы он принимал на вход `selected` с выбранным пунктом и `selectedMultiple`, с массивом выбранных пунктов.
    ```tsx
    /**
    * Обработчик выбора
    */
    onChange?: (payload: {
        selected: OptionShape | null;
        selectedMultiple: OptionShape[];
        name?: string;
    }) => void;
    ```

    3.3. Позволить задавать выбранный пункт не только через массив. null будет использоваться в controlled селекте, если ни один пункт не выбран:
    ```tsx
    /**
    * Список value выбранных пунктов
    */
    selected?: string[] | string | null;
    ```

4. Теперь по умолчанию подсвечивается первый пункт меню