### PR TITLE
feat(core-components-input): hide clear if input is readonly

### DIFF
--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -153,6 +153,18 @@ describe('Input', () => {
 
             expect(getByTestId(dataTestId)).toHaveValue(value);
         });
+
+        it('should not show clear button if input is readonly', () => {
+            const label = 'Очистить';
+
+            const { queryByLabelText, rerender } = render(<Input clear={true} readOnly={true} />);
+
+            expect(queryByLabelText(label)).not.toBeInTheDocument();
+
+            rerender(<Input clear={true} value='123' readOnly={true} />);
+
+            expect(queryByLabelText(label)).not.toBeInTheDocument();
+        });
     });
 
     describe('when component is uncontrolled', () => {
@@ -228,6 +240,17 @@ describe('Input', () => {
             userEvent.click(getByLabelText('Очистить'));
 
             expect(input).toHaveValue('');
+        });
+
+        it('should not show clear button if input is readonly', async () => {
+            const dataTestId = 'test-id';
+            const label = 'Очистить';
+
+            const { queryByLabelText } = render(
+                <Input clear={true} dataTestId={dataTestId} defaultValue='123' readOnly={true} />,
+            );
+
+            expect(queryByLabelText(label)).not.toBeInTheDocument();
         });
     });
 

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -159,6 +159,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             value,
             defaultValue,
             wrapperRef,
+            readOnly,
             ...restProps
         },
         ref,
@@ -174,8 +175,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         const filled = Boolean(uncontrolled ? stateValue : value);
         // отображаем крестик только для заполненного и активного инпута
-        const clearButtonVisible =
-            clear && Boolean(value || (uncontrolled && stateValue)) && !disabled;
+        const clearButtonVisible = clear && filled && !disabled && !readOnly;
 
         const handleInputFocus = useCallback(
             (event: React.FocusEvent<HTMLInputElement>) => {
@@ -294,6 +294,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     value={uncontrolled ? stateValue : value}
                     defaultValue={defaultValue}
+                    readOnly={readOnly}
                     data-test-id={dataTestId}
                 />
             </FormControl>


### PR DESCRIPTION
Не показываем кнопку очистки при readOnly