### PR TITLE
build: add paths to es-modules

### DIFF
--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/bank-card/package.json
+++ b/packages/bank-card/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/circular-progress-bar/package.json
+++ b/packages/circular-progress-bar/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/confirmation/package.json
+++ b/packages/confirmation/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input-autocomplete/package.json
+++ b/packages/input-autocomplete/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/keyboard-focusable/package.json
+++ b/packages/keyboard-focusable/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/masked-input/package.json
+++ b/packages/masked-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/phone-input/package.json
+++ b/packages/phone-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/pure-input/package.json
+++ b/packages/pure-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider-input/package.json
+++ b/packages/slider-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/with-suffix/package.json
+++ b/packages/with-suffix/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,6 +12,7 @@ import {
 } from './tools/rollup/core-components-resolver';
 import ignoreCss from './tools/rollup/ignore-css';
 import processCss from './tools/rollup/process-css';
+import createPackageJson from './tools/rollup/create-package-json';
 
 const currentPackageDir = process.cwd();
 const currentPkg = path.join(currentPackageDir, 'package.json');
@@ -131,6 +132,16 @@ const root = {
             flatten: false,
             targets: [
                 { src: ['dist/**/*', '!**/*.js'], dest: `../../dist/${currentComponentName}` },
+                {
+                    src: 'package.json',
+                    dest: `../../dist/${currentComponentName}`,
+                    transform: () => createPackageJson('./modern/index.js'),
+                },
+                {
+                    src: 'package.json',
+                    dest: `../../dist/${currentComponentName}/cssm`,
+                    transform: () => createPackageJson('../modern/index.js'),
+                },
             ],
         }),
         coreComponentsRootPackageResolver({ currentPackageDir }),

--- a/tools/rollup/create-package-json.js
+++ b/tools/rollup/create-package-json.js
@@ -1,0 +1,12 @@
+const content = `{
+    "module": "%path%"
+}
+`;
+
+/**
+ * Создает контент файла package.json, в котором указывается путь до es-модулей.
+ * Это нужно для корректной работы динамического импорта и three-shaking'а.
+ */
+export default function createPackageJson(path) {
+    return content.replace('%path%', path);
+}

--- a/tools/rollup/create-package-json.js
+++ b/tools/rollup/create-package-json.js
@@ -5,7 +5,7 @@ const content = `{
 
 /**
  * Создает контент файла package.json, в котором указывается путь до es-модулей.
- * Это нужно для корректной работы динамического импорта и three-shaking'а.
+ * Это нужно для корректной работы динамического импорта и tree-shaking'а.
  */
 export default function createPackageJson(path) {
     return content.replace('%path%', path);


### PR DESCRIPTION
- Добавил в `package.json` каждого компонента путь до сборки с es-модулями.
- Для каждого компонента в рут-пакете добавил генерацию файла `package.json` с путем до сборки с es-модулями.

Это добавит возможность корректно собирать бандлы с динамическими импортами внутри наших компонентов.
Также будет работать `tree-shaking`.