### PR TITLE
feat(core-components-form-control): set opacity in disabled state

### DIFF
--- a/packages/form-control/src/index.module.css
+++ b/packages/form-control/src/index.module.css
@@ -15,6 +15,7 @@
     /* disabled */
     --form-control-disabled-bg-color: var(--color-dark-indigo-15);
     --form-control-disabled-border-bottom: 1px dashed var(--color-dark-indigo-30-flat);
+    --form-control-disabled-opacity: 1;
 
     /* focus */
     --form-control-focus-shadow: inset 0 -1px var(--color-dark-indigo);
@@ -195,6 +196,7 @@
 /* DISABLED STATE */
 
 .disabled .inner {
+    opacity: var(--form-control-disabled-opacity);
     border-bottom: var(--form-control-disabled-border-bottom);
     background-color: var(--form-control-disabled-bg-color);
 }

--- a/packages/themes/src/mixins/form-control/click.css
+++ b/packages/themes/src/mixins/form-control/click.css
@@ -19,6 +19,7 @@
     --form-control-labeled-l-paddings: 34px var(--gap-m) 14px;
 
     /* disabled */
+    --form-control-disabled-opacity: 0.5;
     --form-control-disabled-border-bottom: 0;
     --form-control-disabled-bg-color: var(--color-light-bg-tertiary);
 


### PR DESCRIPTION
# Опишите проблему
При выбранной теме "click" у disabled form-control никак не меняется визуальное отображение

# Шаги для воспроизведения
1. Открыть компонент формы, использующий form-control, например, селект
2. Выбрать тему "click"
3. Проставить галку disabled в knobs

# Ожидаемое поведение
Внешний вид индицирует о заблокированности контрола
