### PR TITLE
fix: fix ie bundle

### DIFF
--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/bank-card/package.json
+++ b/packages/bank-card/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -6,7 +6,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/circular-progress-bar/package.json
+++ b/packages/circular-progress-bar/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/confirmation/package.json
+++ b/packages/confirmation/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input-autocomplete/package.json
+++ b/packages/input-autocomplete/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/keyboard-focusable/package.json
+++ b/packages/keyboard-focusable/package.json
@@ -6,7 +6,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/list-header/package.json
+++ b/packages/list-header/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/masked-input/package.json
+++ b/packages/masked-input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/phone-input/package.json
+++ b/packages/phone-input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/plate/package.json
+++ b/packages/plate/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/pure-input/package.json
+++ b/packages/pure-input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider-input/package.json
+++ b/packages/slider-input/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -6,7 +6,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],

--- a/packages/with-suffix/package.json
+++ b/packages/with-suffix/package.json
@@ -5,7 +5,6 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
-    "module": "./dist/modern/index.js",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
Удалил пути до `esmodules`, так как из-за этого ломается `IE11`.
Надо будет потом добавить еще одну сборку - `es5 + esmodules`, чтобы работал `tree-shaking` и `IE11`