### PR TITLE
refactor(slider-input): update input styles

### DIFF
--- a/packages/slider-input/src/Component.tsx
+++ b/packages/slider-input/src/Component.tsx
@@ -174,7 +174,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                     size={size}
                     label={label}
                     disabled={disabled}
-                    className={inputClassName}
+                    className={cn(inputClassName, styles.input)}
                     focusedClassName={styles.focused}
                     bottomAddons={
                         <Slider

--- a/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SliderInput should match snapshot 1`] = `
       class="component s block"
     >
       <div
-        class="formControl inner"
+        class="formControl input inner"
       >
         <div
           class="inputWrapper"

--- a/packages/slider-input/src/index.module.css
+++ b/packages/slider-input/src/index.module.css
@@ -24,6 +24,14 @@
     }
 }
 
+.input {
+    & input,
+    & input + div {
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+    }
+}
+
 .steps {
     @mixin system_14-18_regular;
 


### PR DESCRIPTION
— сделал текст внутри инпута жирным и моноширинным

Вообще стоит отдельным PR изменить стили в инпуте и withSuffix, чтобы они наследовали стили для текста. Но пока проще просто накинуть немножко грязных стилей)