### PR TITLE
fix(circular-progress-bar): fix label width

### DIFF
--- a/packages/circular-progress-bar/src/index.module.css
+++ b/packages/circular-progress-bar/src/index.module.css
@@ -64,6 +64,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
+    width: 100%;
     transform: translate(-50%, -50%);
 }
 


### PR DESCRIPTION
Заставляю контейнер занимать всю доступную ширину
fix #394 