### PR TITLE
fix(mq): use addListener and removeListener

### DIFF
--- a/packages/mq/src/Component.test.tsx
+++ b/packages/mq/src/Component.test.tsx
@@ -6,8 +6,8 @@ import { Mq } from './Component';
 jest.mock('./utils', () => ({
     isPointerEventsSupported: jest.fn(() => true),
     getMatchMedia: jest.fn(() => ({
-        addEventListener: jest.fn,
-        removeEventListener: jest.fn,
+        addListener: jest.fn,
+        removeListener: jest.fn,
         matches: false,
     })),
     releaseMatchMedia: jest.fn,
@@ -15,8 +15,8 @@ jest.mock('./utils', () => ({
 
 function mockGetMatchMedia(result: boolean) {
     (getMatchMedia as jest.Mock).mockReturnValueOnce({
-        addEventListener: jest.fn,
-        removeEventListener: jest.fn,
+        addListener: jest.fn,
+        removeListener: jest.fn,
         matches: result,
     });
 }

--- a/packages/mq/src/useMatchMedia.test.tsx
+++ b/packages/mq/src/useMatchMedia.test.tsx
@@ -7,8 +7,8 @@ jest.mock('./utils');
 
 function mockGetMatchMedia(matches: boolean) {
     (getMatchMedia as jest.Mock).mockReturnValue({
-        addEventListener: jest.fn,
-        removeEventListener: jest.fn,
+        addListener: jest.fn,
+        removeListener: jest.fn,
         matches,
     });
 }

--- a/packages/mq/src/useMatchMedia.tsx
+++ b/packages/mq/src/useMatchMedia.tsx
@@ -13,11 +13,11 @@ export const useMatchMedia = (query: string) => {
 
         const handleMatchChange = () => setMatches(mql.matches);
 
-        mql.addEventListener('change', handleMatchChange);
+        mql.addListener(handleMatchChange);
         handleMatchChange();
 
         return () => {
-            mql.removeEventListener('change', handleMatchChange);
+            mql.removeListener(handleMatchChange);
             releaseMatchMedia(query);
         };
     }, [query]);

--- a/packages/select/src/components/arrow/index.module.css
+++ b/packages/select/src/components/arrow/index.module.css
@@ -8,6 +8,7 @@
 
     background: var(--select-arrow-background);
     background-size: cover;
+    background-position: center;
     transition: opacity 0.2s ease;
 }
 


### PR DESCRIPTION
- Как оказалось addEventListener и removeEventListener не поддерживаются в IE для MediaQueryList.
- Пофиксил позицию стрелки селекта в IE