### PR TITLE
build: add esmodules

### DIFF
--- a/packages/amount-input/package.json
+++ b/packages/amount-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/amount/package.json
+++ b/packages/amount/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/attach/package.json
+++ b/packages/attach/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/bank-card/package.json
+++ b/packages/bank-card/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/card-image/package.json
+++ b/packages/card-image/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/circular-progress-bar/package.json
+++ b/packages/circular-progress-bar/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/confirmation/package.json
+++ b/packages/confirmation/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/form-control/package.json
+++ b/packages/form-control/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input-autocomplete/package.json
+++ b/packages/input-autocomplete/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/intl-phone-input/package.json
+++ b/packages/intl-phone-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "module": "./dist/modern/index.js",
     "files": [
         "dist"

--- a/packages/keyboard-focusable/package.json
+++ b/packages/keyboard-focusable/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/list-header/package.json
+++ b/packages/list-header/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/masked-input/package.json
+++ b/packages/masked-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/mq/package.json
+++ b/packages/mq/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "module": "./dist/modern/index.js",
     "files": [
         "dist"

--- a/packages/phone-input/package.json
+++ b/packages/phone-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/plate/package.json
+++ b/packages/plate/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/progress-bar/package.json
+++ b/packages/progress-bar/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/pure-input/package.json
+++ b/packages/pure-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider-input/package.json
+++ b/packages/slider-input/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -6,6 +6,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/packages/with-suffix/package.json
+++ b/packages/with-suffix/package.json
@@ -5,6 +5,7 @@
     "keywords": [],
     "license": "ISC",
     "main": "dist/index.js",
+    "module": "./dist/esm/index.js",
     "files": [
         "dist"
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,6 +53,9 @@ const postcssPlugin = postcss({
     separateCssFiles: true,
 });
 
+/**
+ * Сборка ES5 с commonjs модулями.
+ */
 const es5 = {
     ...baseConfig,
     output: [
@@ -79,6 +82,9 @@ const es5 = {
     ],
 };
 
+/**
+ * Сборка ES2020 с esm модулями.
+ */
 const modern = {
     ...baseConfig,
     output: [
@@ -110,6 +116,10 @@ const modern = {
     ],
 };
 
+/**
+ * Сборка ES5 с commonjs модулями.
+ * Css-модули поставляются как есть, не компилируются.
+ */
 const cssm = {
     ...baseConfig,
     output: [
@@ -138,6 +148,39 @@ const cssm = {
     ],
 };
 
+/**
+ * Сборка ES5 с esm модулями.
+ */
+const esm = {
+    ...baseConfig,
+    output: [
+        {
+            dir: 'dist/esm',
+            format: 'esm',
+            plugins: [
+                addCssImports({ currentPackageDir }),
+                coreComponentsResolver({ importFrom: 'dist/esm' }),
+            ],
+        },
+    ],
+    plugins: [
+        multiInputPlugin,
+        typescript({
+            outDir: 'dist/esm',
+            tsconfig: resolvedConfig => ({
+                ...resolvedConfig,
+                tsBuildInfoFile: 'tsconfig.tsbuildinfo',
+            }),
+        }),
+        json(),
+        postcssPlugin,
+        copy({
+            flatten: false,
+            targets: [{ src: 'src/**/*.{png,svg,jpg,jpeg}', dest: `dist/esm` }],
+        }),
+    ],
+};
+
 const rootDir = `../../dist/${currentComponentName}`;
 
 const root = {
@@ -151,17 +194,16 @@ const root = {
             flatten: false,
             targets: [
                 { src: ['dist/**/*', '!**/*.js'], dest: rootDir },
-                // TODO: вернуть, когда добавим еще одну сборку с es5 + esmodules
-                // {
-                //     src: 'package.json',
-                //     dest: `../../dist/${currentComponentName}`,
-                //     transform: () => createPackageJson('./modern/index.js'),
-                // },
-                // {
-                //     src: 'package.json',
-                //     dest: `../../dist/${currentComponentName}/cssm`,
-                //     transform: () => createPackageJson('../modern/index.js'),
-                // },
+                {
+                    src: 'package.json',
+                    dest: `../../dist/${currentComponentName}`,
+                    transform: () => createPackageJson('./esm/index.js'),
+                },
+                {
+                    src: 'package.json',
+                    dest: `../../dist/${currentComponentName}/cssm`,
+                    transform: () => createPackageJson('../esm/index.js'),
+                },
             ],
         }),
         coreComponentsRootPackageResolver({ currentPackageDir }),
@@ -174,4 +216,4 @@ const root = {
     ],
 };
 
-export default [es5, modern, cssm, root];
+export default [es5, modern, cssm, esm, root];


### PR DESCRIPTION
Добавил еще одну сборку `es5 + esmodules` и указал путь к ней во всех файлах `package.json`.
Эта сборка нужна для работы `tree-shaking`: если сборщик умеет в `tree-shaking`, то он будет брать модули из этой сборки.