### PR TITLE
feat: add cn for all classNames

### DIFF
--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -184,20 +184,20 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
                         <Fragment>
                             {majorPart}
 
-                            <span className={styles.minorPartAndCurrency}>
+                            <span className={cn(styles.minorPartAndCurrency)}>
                                 {minorPart !== undefined && `,${minorPart}`}
                                 {THINSP}
                                 {currencySymbol}
                             </span>
                         </Fragment>
                     }
-                    suffixContainerClassName={styles.suffixContainer}
+                    suffixContainerClassName={cn(styles.suffixContainer)}
                     clear={clear}
                     placeholder={placeholder}
                     value={inputValue}
                     className={cn(styles.component, className)}
                     focusedClassName={focusedClassName}
-                    inputClassName={styles.input}
+                    inputClassName={cn(styles.input)}
                     onChange={handleChange}
                     onClear={handleClear}
                     dataTestId={dataTestId}

--- a/packages/amount/src/component.tsx
+++ b/packages/amount/src/component.tsx
@@ -27,7 +27,7 @@ export const Amount: React.FC<AmountProps> = ({
     return (
         <span className={cn(styles.component, className)} data-test-id={dataTestId}>
             {majorPart}
-            <span className={styles.minorPartAndCurrency}>
+            <span className={cn(styles.minorPartAndCurrency)}>
                 {minorPart && AMOUNT_MAJOR_MINOR_PARTS_SEPARATOR}
                 {minorPart}
                 {THINSP}

--- a/packages/bank-card/src/Component.tsx
+++ b/packages/bank-card/src/Component.tsx
@@ -108,7 +108,7 @@ export const BankCard = React.forwardRef<HTMLInputElement, BankCardProps>(
 
         const renderRightAddons = useCallback(
             () => (
-                <button type='button' className={styles.usePhoto} onClick={onUsePhoto}>
+                <button type='button' className={cn(styles.usePhoto)} onClick={onUsePhoto}>
                     <CameraMIcon />
                 </button>
             ),
@@ -121,9 +121,9 @@ export const BankCard = React.forwardRef<HTMLInputElement, BankCardProps>(
 
         return (
             <div className={cn(styles.component, className)}>
-                <div className={styles.aspectRatioContainer}>
-                    <div className={styles.content} style={{ backgroundColor }}>
-                        <div className={styles.bankLogo}>{bankLogo}</div>
+                <div className={cn(styles.aspectRatioContainer)}>
+                    <div className={cn(styles.content)} style={{ backgroundColor }}>
+                        <div className={cn(styles.bankLogo)}>{bankLogo}</div>
 
                         <MaskedInput
                             ref={ref}
@@ -132,17 +132,17 @@ export const BankCard = React.forwardRef<HTMLInputElement, BankCardProps>(
                             block={true}
                             label={inputLabel}
                             rightAddons={renderRightAddons()}
-                            inputClassName={styles.input}
-                            labelClassName={styles.label}
-                            filledClassName={styles.filled}
-                            focusedClassName={styles.focused}
+                            inputClassName={cn(styles.input)}
+                            labelClassName={cn(styles.label)}
+                            filledClassName={cn(styles.filled)}
+                            focusedClassName={cn(styles.focused)}
                             onChange={handleInputChange}
                             dataTestId={dataTestId}
                             inputMode='numeric'
                             pattern='[0-9]*'
                         />
 
-                        {brandIcon && <div className={styles.brandLogo}>{brandIcon}</div>}
+                        {brandIcon && <div className={cn(styles.brandLogo)}>{brandIcon}</div>}
                     </div>
                 </div>
             </div>

--- a/packages/card-image/src/Component.tsx
+++ b/packages/card-image/src/Component.tsx
@@ -104,7 +104,7 @@ export const CardImage: FC<CardImageProps> = ({
             {cardId && (
                 <img
                     ref={image}
-                    className={styles.image}
+                    className={cn(styles.image)}
                     width={width}
                     height={height}
                     src={cardImageUrl}

--- a/packages/checkbox-group/src/Component.tsx
+++ b/packages/checkbox-group/src/Component.tsx
@@ -117,7 +117,7 @@ export const CheckboxGroup: FC<CheckboxGroupProps> = ({
                     onChange={handleChange}
                     disabled={disabled || child.props.disabled}
                     checked={checked}
-                    className={styles.hiddenInput}
+                    className={cn(styles.hiddenInput)}
                 />
             </label>
         );
@@ -134,7 +134,7 @@ export const CheckboxGroup: FC<CheckboxGroupProps> = ({
             )}
             data-test-id={dataTestId}
         >
-            {label ? <span className={styles.label}>{label}</span> : null}
+            {label ? <span className={cn(styles.label)}>{label}</span> : null}
 
             {children ? (
                 <div className={cn(styles.checkboxList)}>
@@ -148,7 +148,7 @@ export const CheckboxGroup: FC<CheckboxGroupProps> = ({
                 </div>
             ) : null}
 
-            {error && <span className={styles.errorMessage}>{error}</span>}
+            {error && <span className={cn(styles.errorMessage)}>{error}</span>}
         </div>
     );
 };

--- a/packages/checkbox/src/Component.tsx
+++ b/packages/checkbox/src/Component.tsx
@@ -85,7 +85,7 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
                 })}
                 ref={mergeRefs([labelRef, ref])}
             >
-                <span className={styles.box}>
+                <span className={cn(styles.box)}>
                     <input
                         type='checkbox'
                         onChange={handleChange}
@@ -98,14 +98,14 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
                     {checked && <CheckedIcon />}
 
                     {indeterminate && !checked && (
-                        <IndeterminateIcon className={styles.indeterminateIcon} />
+                        <IndeterminateIcon className={cn(styles.indeterminateIcon)} />
                     )}
                 </span>
 
                 {(label || hint) && (
-                    <span className={styles.content}>
-                        {label && <span className={styles.label}>{label}</span>}
-                        {hint && <span className={styles.hint}>{hint}</span>}
+                    <span className={cn(styles.content)}>
+                        {label && <span className={cn(styles.label)}>{label}</span>}
+                        {hint && <span className={cn(styles.hint)}>{hint}</span>}
                     </span>
                 )}
             </label>

--- a/packages/circular-progress-bar/src/Component.tsx
+++ b/packages/circular-progress-bar/src/Component.tsx
@@ -81,11 +81,11 @@ export const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
         <div className={cn(styles.component, styles[size], className)} data-test-id={dataTestId}>
             <svg
                 viewBox={`0 0 ${memorized.width} ${memorized.height}`}
-                className={styles.svg}
+                className={cn(styles.svg)}
                 xmlns='http://www.w3.org/2000/svg'
             >
                 <circle
-                    className={styles.backgroundCircle}
+                    className={cn(styles.backgroundCircle)}
                     cx={memorized.center}
                     cy={memorized.center}
                     r={memorized.radius}
@@ -100,12 +100,12 @@ export const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
                     transform={`rotate(${-90} ${memorized.center} ${memorized.center})`}
                 />
             </svg>
-            <div className={styles.label}>
+            <div className={cn(styles.label)}>
                 {children || (
                     <React.Fragment>
                         {title && (
                             <Typography.Title
-                                className={styles.title}
+                                className={cn(styles.title)}
                                 color='secondary'
                                 tag='div'
                                 view={size === 'l' ? 'small' : 'xsmall'}
@@ -116,7 +116,7 @@ export const CircularProgressBar: React.FC<CircularProgressBarProps> = ({
                         {subtitle && (
                             <Typography.Text
                                 tag='div'
-                                className={styles.subtitle}
+                                className={cn(styles.subtitle)}
                                 color='primary'
                                 view='primary-small'
                             >

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -278,10 +278,10 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                 )}
 
                 {shouldShowError && (
-                    <div className={styles.error}>
-                        <span className={styles.errorHeader}>{errorTitle}</span>
+                    <div className={cn(styles.error)}>
+                        <span className={cn(styles.errorHeader)}>{errorTitle}</span>
 
-                        <span className={styles.errorText}>{errorText}</span>
+                        <span className={cn(styles.errorText)}>{errorText}</span>
 
                         <Button
                             size='s'
@@ -295,32 +295,32 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                 )}
 
                 {shouldShowHint && (
-                    <div className={styles.phoneHintWrap}>
-                        <span className={styles.errorHeader}>Не&nbsp;приходит сообщение?</span>
+                    <div className={cn(styles.phoneHintWrap)}>
+                        <span className={cn(styles.errorHeader)}>Не&nbsp;приходит сообщение?</span>
 
-                        <span className={styles.phoneHintText}>
+                        <span className={cn(styles.phoneHintText)}>
                             Если у&nbsp;вас сменился номер телефона, пожалуйста, обратитесь
                             в&nbsp;любое отделение банка.
                         </span>
 
-                        <div className={styles.phonesWrap}>
-                            <div className={styles.phoneWrap}>
-                                <Link className={styles.phoneLink} href='tel:+78002000000'>
+                        <div className={cn(styles.phonesWrap)}>
+                            <div className={cn(styles.phoneWrap)}>
+                                <Link className={cn(styles.phoneLink)} href='tel:+78002000000'>
                                     8 800 200-00-00
                                 </Link>
 
-                                <span className={styles.phoneDescription}>
+                                <span className={cn(styles.phoneDescription)}>
                                     {' '}
                                     &mdash;&nbsp;для звонков по&nbsp;России
                                 </span>
                             </div>
 
-                            <div className={styles.phoneWrap}>
-                                <Link className={styles.phoneLink} href='tel:+74957888878'>
+                            <div className={cn(styles.phoneWrap)}>
+                                <Link className={cn(styles.phoneLink)} href='tel:+74957888878'>
                                     +7 495 788-88-78
                                 </Link>
 
-                                <span className={styles.phoneDescription}>
+                                <span className={cn(styles.phoneDescription)}>
                                     {' '}
                                     &mdash;&nbsp;в&nbsp;Москве и&nbsp;за&nbsp;границей
                                 </span>
@@ -328,7 +328,7 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                         </div>
 
                         <Button
-                            className={styles.repeatButton}
+                            className={cn(styles.repeatButton)}
                             size='s'
                             view='secondary'
                             block={true}

--- a/packages/confirmation/src/components/countdown-loader/component.tsx
+++ b/packages/confirmation/src/components/countdown-loader/component.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import cn from 'classnames';
 
 import styles from './index.module.css';
 
@@ -33,7 +34,13 @@ export const CountdownLoader: FC<Props> = ({ progress, className }) => {
                 </mask>
             </defs>
 
-            <circle cx={RADIUS} cy={RADIUS} r={RADIUS} mask='url(#cut)' className={styles.circle} />
+            <circle
+                cx={RADIUS}
+                cy={RADIUS}
+                r={RADIUS}
+                mask='url(#cut)'
+                className={cn(styles.circle)}
+            />
         </svg>
     );
 };

--- a/packages/confirmation/src/components/countdown/component.tsx
+++ b/packages/confirmation/src/components/countdown/component.tsx
@@ -124,12 +124,12 @@ export const Countdown: FC<CountdownProps> = ({
                         </div>
                     )}
 
-                    <div className={styles.info}>Запросить повторно можно через</div>
+                    <div className={cn(styles.info)}>Запросить повторно можно через</div>
 
-                    <div className={styles.loaderWrap}>
-                        <CountdownLoader progress={progress} className={styles.loader} />
+                    <div className={cn(styles.loaderWrap)}>
+                        <CountdownLoader progress={progress} className={cn(styles.loader)} />
 
-                        <div className={styles.timePassed}>
+                        <div className={cn(styles.timePassed)}>
                             {formatMsAsMinutes(duration - timePassed)}
                         </div>
                     </div>

--- a/packages/confirmation/src/components/sign-confirmation/component.tsx
+++ b/packages/confirmation/src/components/sign-confirmation/component.tsx
@@ -96,29 +96,29 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
 
     return (
         <div className={cn(styles.component, styles[alignContent])}>
-            <span className={styles.header}>{title}</span>
+            <span className={cn(styles.header)}>{title}</span>
 
-            <div className={styles.inputContainer}>
+            <div className={cn(styles.inputContainer)}>
                 <CodeInput
                     processing={processing}
                     error={error}
                     value={inputValue}
                     ref={inputRef}
                     slotsCount={requiredCharAmount}
-                    className={styles.codeInput}
+                    className={cn(styles.codeInput)}
                     alignContent={alignContent}
                     handleChange={handleInputChange}
                     handleInputKeyDown={handleInputKeyDown}
                 />
 
-                {displayedError && <div className={styles.error}>{displayedError}</div>}
+                {displayedError && <div className={cn(styles.error)}>{displayedError}</div>}
             </div>
 
             {processing && (
-                <div className={styles.loaderWrap}>
+                <div className={cn(styles.loaderWrap)}>
                     <Loader />
 
-                    <span className={styles.loaderText}>
+                    <span className={cn(styles.loaderText)}>
                         {codeChecking ? codeCheckingText : codeSendingText}
                     </span>
                 </div>
@@ -130,7 +130,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
                         duration={countdownDuration}
                         phone={phone}
                         hasPhoneMask={hasPhoneMask}
-                        className={styles.countdown}
+                        className={cn(styles.countdown)}
                         alignContent={alignContent}
                         onRepeatSms={onSmsRetryClick}
                         onCountdownFinished={onCountdownFinished}
@@ -139,10 +139,10 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
             )}
 
             {smsHintVisible && (
-                <div className={styles.smsComeLinkWrap}>
+                <div className={cn(styles.smsComeLinkWrap)}>
                     <Link
                         onClick={onSmsHintLinkClick}
-                        className={styles.smsComeLink}
+                        className={cn(styles.smsComeLink)}
                         view='secondary'
                     >
                         Не приходит сообщение?

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -136,14 +136,14 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
                         </div>
                     )}
 
-                    <div className={styles.inputWrapper}>
+                    <div className={cn(styles.inputWrapper)}>
                         {label && (
                             <div className={cn(styles.label, labelClassName)}>
-                                <span className={styles.labelInner}>{label}</span>
+                                <span className={cn(styles.labelInner)}>{label}</span>
                             </div>
                         )}
 
-                        <div className={styles.input}>{children}</div>
+                        <div className={cn(styles.input)}>{children}</div>
                     </div>
 
                     {rightAddons && (

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -267,14 +267,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                                 view='ghost'
                                 disabled={disabled}
                                 aria-label='Очистить'
-                                className={styles.clearButton}
+                                className={cn(styles.clearButton)}
                                 onClick={handleClear}
                             >
                                 <span className={cn(styles.clearIcon)} />
                             </Button>
                         )}
-                        {error && <span className={styles.errorIcon} />}
-                        {success && !error && <span className={styles.successIcon} />}
+                        {error && <span className={cn(styles.errorIcon)} />}
+                        {success && !error && <span className={cn(styles.successIcon)} />}
                         {rightAddons}
                     </Fragment>
                 )

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -176,7 +176,7 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
                 type='tel'
                 ref={mergeRefs([inputRef, ref])}
                 className={cn(className, styles[size])}
-                addonsClassName={styles.addons}
+                addonsClassName={cn(styles.addons)}
                 size={size}
                 leftAddons={
                     <CountriesSelect

--- a/packages/intl-phone-input/src/components/select-field/component.tsx
+++ b/packages/intl-phone-input/src/components/select-field/component.tsx
@@ -22,7 +22,7 @@ export const SelectField: FC<FieldProps> = ({ selected, Arrow, size, innerProps 
                 [styles.focusVisible]: focusVisible,
             })}
         >
-            <div {...innerProps} className={styles.inner}>
+            <div {...innerProps} className={cn(styles.inner)}>
                 {selected && (
                     <span>
                         <FlagIcon country={selected.value} size={size} />

--- a/packages/intl-phone-input/src/components/select/component.tsx
+++ b/packages/intl-phone-input/src/components/select/component.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useMemo } from 'react';
+import cn from 'classnames';
 
 import { Select, SelectProps } from '@alfalab/core-components-select';
 import { Country } from '@alfalab/utils';
@@ -29,12 +30,12 @@ export const CountriesSelect: FC<CountriesSelectProps> = ({
                 key: iso2,
                 value: iso2,
                 content: (
-                    <span className={styles.option}>
-                        <FlagIcon country={iso2} className={styles.flag} />
+                    <span className={cn(styles.option)}>
+                        <FlagIcon country={iso2} className={cn(styles.flag)} />
 
-                        <span className={styles.optionTextWrap}>
-                            <span className={styles.countryName}>{name}</span>
-                            <span className={styles.dialCode}>+{dialCode}</span>
+                        <span className={cn(styles.optionTextWrap)}>
+                            <span className={cn(styles.countryName)}>{name}</span>
+                            <span className={cn(styles.dialCode)}>+{dialCode}</span>
                         </span>
                     </span>
                 ),
@@ -50,7 +51,7 @@ export const CountriesSelect: FC<CountriesSelectProps> = ({
             selected={selected}
             onChange={onChange}
             Field={SelectField}
-            className={styles.component}
+            className={cn(styles.component)}
         />
     );
 };

--- a/packages/list/src/Component.tsx
+++ b/packages/list/src/Component.tsx
@@ -53,7 +53,7 @@ export const List: React.FC<ListProps> = ({
         <Component className={listClassNames} data-test-id={dataTestId}>
             {Children.map(children, child => (
                 <li className={itemClassNames}>
-                    {Component !== 'ol' && <div className={styles.slot}>{markerType}</div>}
+                    {Component !== 'ol' && <div className={cn(styles.slot)}>{markerType}</div>}
                     {child}
                 </li>
             ))}

--- a/packages/radio-group/src/Component.tsx
+++ b/packages/radio-group/src/Component.tsx
@@ -146,7 +146,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
                         disabled={disabled || child.props.disabled}
                         name={name}
                         checked={checked}
-                        className={styles.hiddenInput}
+                        className={cn(styles.hiddenInput)}
                     />
                 </label>
             );
@@ -164,7 +164,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
                 data-test-id={dataTestId}
                 ref={ref}
             >
-                {label ? <span className={styles.label}>{label}</span> : null}
+                {label ? <span className={cn(styles.label)}>{label}</span> : null}
 
                 {children ? (
                     <div className={cn(styles.radioList)}>
@@ -178,7 +178,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
                     </div>
                 ) : null}
 
-                {error && <span className={styles.errorMessage}>{error}</span>}
+                {error && <span className={cn(styles.errorMessage)}>{error}</span>}
             </div>
         );
     },

--- a/packages/radio/src/Component.tsx
+++ b/packages/radio/src/Component.tsx
@@ -92,10 +92,10 @@ export const Radio = forwardRef<HTMLLabelElement, RadioProps>(
                     name={name}
                     {...restProps}
                 />
-                <span className={styles.circle} />
-                <span className={styles.content}>
-                    <span className={styles.label}>{label}</span>
-                    {hint && <span className={styles.hint}>{hint}</span>}
+                <span className={cn(styles.circle)} />
+                <span className={cn(styles.content)}>
+                    <span className={cn(styles.label)}>{label}</span>
+                    {hint && <span className={cn(styles.hint)}>{hint}</span>}
                 </span>
             </label>
         );

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -267,7 +267,7 @@ export const BaseSelect = forwardRef(
             return (
                 <NativeSelect
                     {...menuProps}
-                    className={styles.nativeSelect}
+                    className={cn(styles.nativeSelect)}
                     disabled={disabled}
                     multiple={multiple}
                     name={name}
@@ -321,17 +321,17 @@ export const BaseSelect = forwardRef(
                 {name && !nativeSelect && renderValue()}
 
                 {!nativeSelect && (
-                    <div {...menuProps} className={styles.listWrapper}>
+                    <div {...menuProps} className={cn(styles.listWrapper)}>
                         <Popover
                             open={open}
                             withTransition={false}
                             anchorElement={fieldRef.current as HTMLElement}
                             position='bottom-start'
                             getPortalContainer={getPortalContainer}
-                            popperClassName={styles.popover}
+                            popperClassName={cn(styles.popover)}
                         >
                             {flatOptions.length > 0 && (
-                                <div className={styles.optionsList}>
+                                <div className={cn(styles.optionsList)}>
                                     <OptionsList
                                         flatOptions={flatOptions}
                                         highlightedIndex={highlightedIndex}

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -40,7 +40,7 @@ export const Field = ({
 
     return (
         <div
-            className={styles.component}
+            className={cn(styles.component)}
             ref={wrapperRef}
             onFocus={handleFocus}
             onBlur={handleBlur}
@@ -71,11 +71,11 @@ export const Field = ({
                 {...restProps}
                 {...innerProps}
             >
-                <div className={styles.contentWrapper}>
+                <div className={cn(styles.contentWrapper)}>
                     {placeholder && !filled && (
-                        <span className={styles.placeholder}>{placeholder}</span>
+                        <span className={cn(styles.placeholder)}>{placeholder}</span>
                     )}
-                    {filled && <div className={styles.value}>{value}</div>}
+                    {filled && <div className={cn(styles.value)}>{value}</div>}
                 </div>
             </FormControl>
         </div>

--- a/packages/select/src/components/optgroup/Component.tsx
+++ b/packages/select/src/components/optgroup/Component.tsx
@@ -7,7 +7,7 @@ import styles from './index.module.css';
 export const Optgroup = ({ children, label, size = 's' }: OptgroupProps) => (
     <React.Fragment>
         <div className={cn(styles.optgroup, styles[size])}>
-            <span className={styles.label}>{label}</span>
+            <span className={cn(styles.label)}>{label}</span>
         </div>
         {children}
     </React.Fragment>

--- a/packages/select/src/components/option/Component.tsx
+++ b/packages/select/src/components/option/Component.tsx
@@ -25,6 +25,6 @@ export const Option: FC<OptionProps> = ({
         })}
     >
         {Checkmark && <Checkmark selected={selected} />}
-        <div className={styles.content}>{children || option.content || option.key}</div>
+        <div className={cn(styles.content)}>{children || option.content || option.key}</div>
     </div>
 );

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -86,7 +86,7 @@ export const VirtualOptionsList = ({
     return (
         <div className={cn(styles.virtualOptionsList, styles[size])} ref={parentRef}>
             <div
-                className={styles.inner}
+                className={cn(styles.inner)}
                 style={{
                     height: `${rowVirtualizer.totalSize}px`,
                 }}

--- a/packages/slider-input/src/Component.tsx
+++ b/packages/slider-input/src/Component.tsx
@@ -175,7 +175,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                     label={label}
                     disabled={disabled}
                     className={cn(inputClassName, styles.input)}
-                    focusedClassName={styles.focused}
+                    focusedClassName={cn(styles.focused)}
                     bottomAddons={
                         <Slider
                             min={min}
@@ -191,7 +191,7 @@ export const SliderInput = forwardRef<HTMLInputElement, SliderInputProps>(
                     rightAddons={
                         (info || rightAddons) && (
                             <Fragment>
-                                {info && <span className={styles.info}>{info}</span>}
+                                {info && <span className={cn(styles.info)}>{info}</span>}
                                 {rightAddons}
                             </Fragment>
                         )

--- a/packages/slider/src/Component.tsx
+++ b/packages/slider/src/Component.tsx
@@ -81,7 +81,7 @@ export const Slider = forwardRef<HTMLInputElement, SliderProps>(
 
         return (
             <div className={cn(styles.component, className)} data-test-id={dataTestId}>
-                <div className={styles.rangeWrapper}>
+                <div className={cn(styles.rangeWrapper)}>
                     <input
                         {...rangeProps}
                         {...restProps}

--- a/packages/switch/src/Component.tsx
+++ b/packages/switch/src/Component.tsx
@@ -105,12 +105,12 @@ export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
                     {...restProps}
                 />
 
-                <span className={styles.switch} />
+                <span className={cn(styles.switch)} />
 
                 {(label || hint) && (
-                    <span className={styles.content}>
-                        {label && <span className={styles.label}>{label}</span>}
-                        {hint && <span className={styles.hint}>{hint}</span>}
+                    <span className={cn(styles.content)}>
+                        {label && <span className={cn(styles.label)}>{label}</span>}
+                        {hint && <span className={cn(styles.hint)}>{hint}</span>}
                     </span>
                 )}
             </label>

--- a/packages/with-suffix/src/Component.tsx
+++ b/packages/with-suffix/src/Component.tsx
@@ -103,7 +103,7 @@ export const withSuffix = (Input: FC<InputProps & RefAttributes<HTMLInputElement
                     />
                     <Portal getPortalContainer={getPortalContainer}>
                         <div className={cn(styles.suffixContainer, suffixContainerClassName)}>
-                            <span className={styles.spacer}>{visibleValue}</span>
+                            <span className={cn(styles.spacer)}>{visibleValue}</span>
                             {suffix && (
                                 <div className={cn(styles.suffix, { [styles.disabled]: disabled })}>
                                     {suffix}


### PR DESCRIPTION
# Опишите проблему
Для всем компонентов, на которые вешаются классы аля `className={styles.component}` нужно прокидывать название класса через либу `classnames` аля `className={cn(styles.component)}`.
Я эту фишку использую, чтобы при сборке переопределить зависимость `classnames`и подсунуть вместо нее свой вариант библиотеки. 
```
config.plugins.push(
            new webpack.NormalModuleReplacementPlugin(
                /^classnames$/,
                require.resolve('./src/client/utils/classnames') // Добавляем префикс для всех core-components
            )
        );
```
Конкретно у меня на проекте это используется, чтобы добавить для каждого компонента доп. css класс

```
// ./src/client/utils/classnames'
...
if (classes.length) {
     classes.push(CSS_CUSTOM_PREFIX);
}

return classes.join(' ');
```

PS: для библиотеки arui-feather используется такое переопределение
```
config.plugins.push(
            new webpack.NormalModuleReplacementPlugin(
                /^bem-react-classname$/,
                require.resolve('./src/client/utils/class-name')
            )
        );
```
Т.к. в этом пакете на все блоки вешаются классы через `bem-react-classname`.

# Чек лист
- [x] Тесты
- [ ] Документация

# Дополнительная информация
Сделал для всех пакетов, кроме tabs. 
В нем валяться тесты из-за того, что
было
```
<span>bla</span>
```
Стало
```
<span class=''>bla</span>
```

Буду рад, если подскажете как пересобрать snapshots для табов, чтобы все заработало.
