### PR TITLE
Добавляет возможность изменять максимальное количество символов до запятой в AmountInput

### DIFF
--- a/packages/amount-input/src/Component.stories.mdx
+++ b/packages/amount-input/src/Component.stories.mdx
@@ -22,6 +22,7 @@ import { name, version } from '../package.json';
     <AmountInput
         value={number('value', null)}
         currency={text('currency', 'RUR')}
+        integerLength={number('maxLength', 9)}
         minority={number('minority', 100)}
         bold={boolean('bold', true)}
         block={boolean('block', false)}

--- a/packages/amount-input/src/Component.stories.mdx
+++ b/packages/amount-input/src/Component.stories.mdx
@@ -22,7 +22,7 @@ import { name, version } from '../package.json';
     <AmountInput
         value={number('value', null)}
         currency={text('currency', 'RUR')}
-        integerLength={number('maxLength', 9)}
+        integerLength={number('integerLength', 9)}
         minority={number('minority', 100)}
         bold={boolean('bold', true)}
         block={boolean('block', false)}

--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -21,6 +21,11 @@ export type AmountInputProps = Omit<InputProps, 'value' | 'onChange' | 'type'> &
     currency?: CurrencyCodes;
 
     /**
+     * Максимальное число знаков до запятой
+     */
+    integerLength?: number;
+
+    /**
      * Минорные единицы
      */
     minority?: number;
@@ -61,6 +66,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
     (
         {
             value = null,
+            integerLength = 9,
             minority = 100,
             currency = 'RUR',
             placeholder = `0\u2009${getCurrencySymbol(currency) || ''}`,
@@ -106,7 +112,9 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
         const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
             const input = e.target;
             const enteredValue = input.value.replace(/\s/g, '').replace('.', ',');
-            const isCorrectEnteredValue = /(^[0-9]{1,9}(,([0-9]+)?)?$|^\s*$)/.test(enteredValue);
+            const isCorrectEnteredValue = RegExp(
+                `(^[0-9]{1,${integerLength}}(,([0-9]+)?)?$|^\\s*$)`,
+            ).test(enteredValue);
 
             if (isCorrectEnteredValue) {
                 const newFormatedValue = getFormatedValue(enteredValue, currency, minority);


### PR DESCRIPTION
# Опишите проблему
В `AmountInput` захардкожено максимальное количество символов до запятой.

# Шаги для воспроизведения
Попробовать ввести в `AmountInput` 999 999 999 999.

# Ожидаемое поведение
Можно дать пользователю вводить более 9 символов до запятой. 

# Дополнительная информация
prop integerLength - аналог [integerLength из MoneyInput](https://github.com/alfa-laboratory/arui-feather/blob/master/src/money-input/money-input.tsx#L60) 