### PR TITLE
feat(themes): add dark theme mixins

### DIFF
--- a/bin/build-themes.js
+++ b/bin/build-themes.js
@@ -85,7 +85,14 @@ const processPostCss = async (content, cssFile) =>
         const vars = extractContentFromMixins(content);
 
         shell.mkdir('-p', `../css/colors`);
-        fs.writeFileSync(`../css/colors/${path.basename(file)}`, toRoot(vars));
+
+        const css = toRoot(vars);
+
+        fs.writeFileSync(`../css/colors/${path.basename(file)}`, css);
+        fs.writeFileSync(
+            `../css/colors/${path.basename(file).replace(/\.css$/, '.js')}`,
+            `module.exports = \`${css}\``,
+        );
     });
 
     // Переносим сгенерированные css-файлы в /dist

--- a/bin/build-themes.js
+++ b/bin/build-themes.js
@@ -78,6 +78,16 @@ const processPostCss = async (content, cssFile) =>
         }
     }
 
+    const colorsFiles = glob.sync('./colors/*.css', {});
+
+    colorsFiles.forEach(file => {
+        const content = fs.readFileSync(file, 'utf-8');
+        const vars = extractContentFromMixins(content);
+
+        shell.mkdir('-p', `../css/colors`);
+        fs.writeFileSync(`../css/colors/${path.basename(file)}`, toRoot(vars));
+    });
+
     // Переносим сгенерированные css-файлы в /dist
     shell.cd('../');
     shell.cp('-R', './css/.', './');

--- a/packages/dark-theme-styles-injector/package.json
+++ b/packages/dark-theme-styles-injector/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "@alfalab/core-components-dark-theme-styles-injector",
+    "version": "1.0.0",
+    "description": "Inject dark theme styles in page",
+    "keywords": [],
+    "license": "ISC",
+    "main": "dist/index.js",
+    "files": [
+        "dist"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "peerDependencies": {
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+    },
+    "dependencies": {
+        "@alfalab/core-components-themes": "^2.6.0"
+    }
+}

--- a/packages/dark-theme-styles-injector/package.json
+++ b/packages/dark-theme-styles-injector/package.json
@@ -16,6 +16,6 @@
         "react-dom": "^16.9.0"
     },
     "dependencies": {
-        "@alfalab/core-components-themes": "^2.6.0"
+        "@alfalab/core-components-themes": "^2.5.1"
     }
 }

--- a/packages/dark-theme-styles-injector/src/component.tsx
+++ b/packages/dark-theme-styles-injector/src/component.tsx
@@ -1,10 +1,6 @@
 import React, { FC } from 'react';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import colorsIndigo from '@alfalab/core-components-themes/dist/colors/colors-indigo';
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
 import colorsBluetint from '@alfalab/core-components-themes/dist/colors/colors-bluetint';
 
 const colorsMap = {

--- a/packages/dark-theme-styles-injector/src/component.tsx
+++ b/packages/dark-theme-styles-injector/src/component.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import colorsIndigo from '@alfalab/core-components-themes/dist/colors/colors-indigo';
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore
+import colorsBluetint from '@alfalab/core-components-themes/dist/colors/colors-bluetint';
+
+const colorsMap = {
+    indigo: colorsIndigo,
+    bluetint: colorsBluetint,
+};
+
+export type DarkThemeStylesInjectorProps = {
+    colors: 'indigo' | 'bluetint';
+    styles?: string;
+};
+
+export const DarkThemeStylesInjector: FC<DarkThemeStylesInjectorProps> = ({
+    colors,
+    styles = '',
+}) => {
+    return (
+        <style>
+            {colorsMap[colors]}
+            {styles}
+        </style>
+    );
+};

--- a/packages/dark-theme-styles-injector/src/index.ts
+++ b/packages/dark-theme-styles-injector/src/index.ts
@@ -1,0 +1,1 @@
+export * from './component';

--- a/packages/dark-theme-styles-injector/tsconfig.json
+++ b/packages/dark-theme-styles-injector/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "include": ["src", "../../typings"],
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDirs": ["src"],
+        "baseUrl": ".",
+        "paths": {
+            "@alfalab/core-components-*": ["../*/src"]
+        }
+    }
+}

--- a/packages/themes/src/mixins/colors/colors-bluetint.css
+++ b/packages/themes/src/mixins/colors/colors-bluetint.css
@@ -1,0 +1,59 @@
+@define-mixin dark-theme {
+    --color-light-bg-accent: var(--color-dark-bg-accent);
+    --color-light-bg-attention-muted: var(--color-dark-bg-attention-muted);
+    --color-light-bg-info: var(--color-dark-bg-info);
+    --color-light-bg-negative-muted: var(--color-dark-bg-negative-muted);
+    --color-light-bg-neutral: var(--color-dark-bg-neutral);
+    --color-light-bg-opaque: var(--color-dark-bg-opaque);
+    --color-light-bg-overlay: var(--color-dark-bg-overlay);
+    --color-light-bg-positive-muted: var(--color-dark-bg-positive-muted);
+    --color-light-bg-primary: var(--color-dark-bg-primary);
+    --color-light-bg-primary-inverted: var(--color-dark-bg-primary-inverted);
+    --color-light-bg-secondary: var(--color-dark-bg-secondary);
+    --color-light-bg-secondary-inverted: var(--color-dark-bg-secondary-inverted);
+    --color-light-bg-tertiary: var(--color-dark-bg-tertiary);
+    --color-light-bg-tertiary-inverted: var(--color-dark-bg-tertiary-inverted);
+    --color-light-border-accent: var(--color-dark-border-accent);
+    --color-light-border-key: var(--color-dark-border-key);
+    --color-light-border-key-inverted: var(--color-dark-border-key-inverted);
+    --color-light-border-primary: var(--color-dark-border-primary);
+    --color-light-border-secondary: var(--color-dark-border-secondary);
+    --color-light-border-secondary-inverted: var(--color-dark-border-secondary-inverted);
+    --color-light-border-tertiary: var(--color-dark-border-tertiary);
+    --color-light-border-tertiary-inverted: var(--color-dark-border-tertiary-inverted);
+    --color-light-graphic-accent: var(--color-dark-graphic-accent);
+    --color-light-graphic-attention: var(--color-dark-graphic-attention);
+    --color-light-graphic-link: var(--color-dark-graphic-link);
+    --color-light-graphic-negative: var(--color-dark-graphic-negative);
+    --color-light-graphic-neutral: var(--color-dark-graphic-neutral);
+    --color-light-graphic-positive: var(--color-dark-graphic-positive);
+    --color-light-graphic-primary: var(--color-dark-graphic-primary);
+    --color-light-graphic-primary-inverted: var(--color-dark-graphic-primary-inverted);
+    --color-light-graphic-secondary: var(--color-dark-graphic-secondary);
+    --color-light-graphic-tertiary: var(--color-dark-graphic-tertiary);
+    --color-light-specialbg-nulled: var(--color-dark-specialbg-nulled);
+    --color-light-specialbg-primary-grouped: var(--color-dark-specialbg-primary-grouped);
+    --color-light-specialbg-secondary-grouped: var(--color-dark-specialbg-secondary-grouped);
+    --color-light-specialbg-tertiary-grouped: var(--color-dark-specialbg-tertiary-grouped);
+    --color-light-text-accent: var(--color-dark-text-accent);
+    --color-light-text-attention: var(--color-dark-text-attention);
+    --color-light-text-disabled: var(--color-dark-text-disabled);
+    --color-light-text-disabled-transparent: var(--color-dark-text-disabled-transparent);
+    --color-light-text-link: var(--color-dark-text-link);
+    --color-light-text-negative: var(--color-dark-text-negative);
+    --color-light-text-positive: var(--color-dark-text-positive);
+    --color-light-text-primary: var(--color-dark-text-primary);
+    --color-light-text-primary-inverted: var(--color-dark-text-primary-inverted);
+    --color-light-text-secondary: var(--color-dark-text-secondary);
+    --color-light-text-secondary-inverted: var(--color-dark-text-secondary-inverted);
+    --color-light-text-secondary-inverted-transparent: var(
+        --color-dark-text-secondary-inverted-transparent
+    );
+    --color-light-text-secondary-transparent: var(--color-dark-text-secondary-transparent);
+    --color-light-text-tertiary: var(--color-dark-text-tertiary);
+    --color-light-text-tertiary-inverted: var(--color-dark-text-tertiary-inverted);
+    --color-light-text-tertiary-inverted-transparent: var(
+        --color-dark-text-tertiary-inverted-transparent
+    );
+    --color-light-text-tertiary-transparent: var(--color-dark-text-tertiary-transparent);
+}

--- a/packages/themes/src/mixins/colors/colors-indigo.css
+++ b/packages/themes/src/mixins/colors/colors-indigo.css
@@ -1,0 +1,60 @@
+@define-mixin dark-theme {
+    --color-light-bg-accent: var(--color-dark-bg-accent);
+    --color-light-bg-attention-muted: var(--color-dark-bg-attention-muted);
+    --color-light-bg-negative-muted: var(--color-dark-bg-negative-muted);
+    --color-light-bg-neutral: var(--color-dark-bg-neutral);
+    --color-light-bg-opaque: var(--color-dark-bg-opaque);
+    --color-light-bg-overlay: var(--color-dark-bg-overlay);
+    --color-light-bg-positive-muted: var(--color-dark-bg-positive-muted);
+    --color-light-bg-primary: var(--color-dark-bg-primary);
+    --color-light-bg-primary-inverted: var(--color-dark-bg-primary-inverted);
+    --color-light-bg-secondary: var(--color-dark-bg-secondary);
+    --color-light-bg-secondary-inverted: var(--color-dark-bg-secondary-inverted);
+    --color-light-bg-tertiary: var(--color-dark-bg-tertiary);
+    --color-light-bg-tertiary-inverted: var(--color-dark-bg-tertiary-inverted);
+    --color-light-border-accent: var(--color-dark-border-accent);
+    --color-light-border-key: var(--color-dark-border-key);
+    --color-light-border-key-inverted: var(--color-dark-border-key-inverted);
+    --color-light-border-link: var(--color-dark-border-link);
+    --color-light-border-primary: var(--color-dark-border-primary);
+    --color-light-border-secondary: var(--color-dark-border-secondary);
+    --color-light-border-secondary-inverted: var(--color-dark-border-secondary-inverted);
+    --color-light-border-tertiary: var(--color-dark-border-tertiary);
+    --color-light-border-tertiary-inverted: var(--color-dark-border-tertiary-inverted);
+    --color-light-graphic-accent: var(--color-dark-graphic-accent);
+    --color-light-graphic-attention: var(--color-dark-graphic-attention);
+    --color-light-graphic-link: var(--color-dark-graphic-link);
+    --color-light-graphic-negative: var(--color-dark-graphic-negative);
+    --color-light-graphic-neutral: var(--color-dark-graphic-neutral);
+    --color-light-graphic-positive: var(--color-dark-graphic-positive);
+    --color-light-graphic-primary: var(--color-dark-graphic-primary);
+    --color-light-graphic-primary-inverted: var(--color-dark-graphic-primary-inverted);
+    --color-light-graphic-secondary: var(--color-dark-graphic-secondary);
+    --color-light-graphic-tertiary: var(--color-dark-graphic-tertiary);
+    --color-light-specialbg-component: var(--color-dark-specialbg-component);
+    --color-light-specialbg-nulled: var(--color-dark-specialbg-nulled);
+    --color-light-specialbg-primary-grouped: var(--color-dark-specialbg-primary-grouped);
+    --color-light-specialbg-secondary-grouped: var(--color-dark-specialbg-secondary-grouped);
+    --color-light-specialbg-tertiary-grouped: var(--color-dark-specialbg-tertiary-grouped);
+    --color-light-text-accent: var(--color-dark-text-accent);
+    --color-light-text-attention: var(--color-dark-text-attention);
+    --color-light-text-disabled: var(--color-dark-text-disabled);
+    --color-light-text-disabled-transparent: var(--color-dark-text-disabled-transparent);
+    --color-light-text-link: var(--color-dark-text-link);
+    --color-light-text-negative: var(--color-dark-text-negative);
+    --color-light-text-positive: var(--color-dark-text-positive);
+    --color-light-text-primary: var(--color-dark-text-primary);
+    --color-light-text-primary-inverted: var(--color-dark-text-primary-inverted);
+    --color-light-text-secondary: var(--color-dark-text-secondary);
+    --color-light-text-secondary-inverted: var(--color-dark-text-secondary-inverted);
+    --color-light-text-secondary-inverted-transparent: var(
+        --color-dark-text-secondary-inverted-transparent
+    );
+    --color-light-text-secondary-transparent: var(--color-dark-text-secondary-transparent);
+    --color-light-text-tertiary: var(--color-dark-text-tertiary);
+    --color-light-text-tertiary-inverted: var(--color-dark-text-tertiary-inverted);
+    --color-light-text-tertiary-inverted-transparent: var(
+        --color-dark-text-tertiary-inverted-transparent
+    );
+    --color-light-text-tertiary-transparent: var(--color-dark-text-tertiary-transparent);
+}

--- a/tools/rollup/process-css.js
+++ b/tools/rollup/process-css.js
@@ -1,6 +1,4 @@
 import globby from 'globby';
-import { promisify } from 'util';
-import fs from 'fs';
 import postcss from 'postcss';
 import path from 'path';
 

--- a/tools/update-colors.js
+++ b/tools/update-colors.js
@@ -12,6 +12,7 @@ glob(path.join(colorsDir, 'colors*.json'), {}, (err, files) => {
         const colors = require(pathname);
 
         let css = '';
+
         Object.entries(colors).forEach(([name, token]) => {
             if (token.deprecated) {
                 return;
@@ -31,5 +32,48 @@ glob(path.join(colorsDir, 'colors*.json'), {}, (err, files) => {
         );
 
         fs.writeFileSync(cssPath, `:root {\n${css}}\n`);
+
+        updateDarkThemeMixins(pathname, colors);
     });
 });
+
+function updateDarkThemeMixins(pathname, colors) {
+    const findPair = lightColor =>
+        Object.keys(colors).find(
+            color =>
+                color.includes('dark') &&
+                lightColor.replace(/^light_/, '') === color.replace(/^dark_/, ''),
+        );
+
+    const mixinsDir = path.resolve(__dirname, '../packages/themes/src/mixins/colors');
+    const mixinFileName = path
+        .basename(pathname)
+        .replace('.json', '.css')
+        .replace('_', '-');
+
+    let css = '@define-mixin dark-theme {\n';
+
+    if (pathname.includes('bluetint') || pathname.includes('indigo')) {
+        const colorsMap = {
+            /** [lightColorName: string]: string (darkColorName) */
+        };
+
+        Object.keys(colors).forEach(color => {
+            if (/^light_/.test(color)) {
+                const pair = findPair(color);
+
+                if (pair) {
+                    const formatedName = color.replace(UNDERSCORE_RE, DASH);
+                    const formattedPairName = pair.replace(UNDERSCORE_RE, DASH);
+                    css += `    --color-${formatedName}: var(--color-${formattedPairName});\n`;
+                } else {
+                    console.warn(`No pair found for '${color}' color.`);
+                }
+            }
+        });
+
+        css += '}';
+
+        fs.writeFileSync(path.join(mixinsDir, mixinFileName), css);
+    }
+}

--- a/typings/themes.d.ts
+++ b/typings/themes.d.ts
@@ -1,0 +1,12 @@
+declare module '@alfalab/core-components-themes/dist/colors/colors-indigo' {
+    const css: string;
+
+    export default css;
+}
+
+declare module '@alfalab/core-components-themes/dist/colors/colors-bluetint' {
+    const css: string;
+
+    export default css;
+}
+


### PR DESCRIPTION
- Добавил генерацию миксинов, в которых светлые цвета заменяются на темные
- Добавил сами миксины: `themes/src/mixins/colors/`
- Добавил компонент `DarkThemeStylesInjector`, который вставляет переопределение цветов на страницу

Пример использования компонента `DarkThemeStylesInjector` в [паспорте](http://git.moscow.alfaintra.net/projects/PAS/repos/retail-passport-ui/pull-requests/686/overview)