### PR TITLE
fix(circular-progress-bar): change max-height

### DIFF
--- a/packages/circular-progress-bar/src/index.module.css
+++ b/packages/circular-progress-bar/src/index.module.css
@@ -42,7 +42,7 @@
     }
 
     & .title {
-        max-height: 40px;
+        max-height: 32px;
     }
 }
 


### PR DESCRIPTION
Ссылка на figma https://www.figma.com/file/KlFOLLkKO8rtvvQE3RXuhq/Click-Library?node-id=11501%3A44539
Сделал в соответствии с макетом.
Было:
<img width="166" alt="Screen Shot 2020-12-14 at 17 54 25" src="https://user-images.githubusercontent.com/35544150/102096306-9c377100-3e35-11eb-863d-34809b2cb9a6.png">
Стало:
<img width="155" alt="Screen Shot 2020-12-14 at 17 54 14" src="https://user-images.githubusercontent.com/35544150/102096335-a2c5e880-3e35-11eb-97a5-f9c608c6c2dc.png">

