### PR TITLE
fix: change icons imports paths

### DIFF
--- a/packages/attach/src/Component.tsx
+++ b/packages/attach/src/Component.tsx
@@ -10,7 +10,8 @@ import mergeRefs from 'react-merge-refs';
 import { Button, ButtonProps } from '@alfalab/core-components-button';
 import { ProgressBar } from '@alfalab/core-components-progress-bar';
 import { KeyboardFocusable } from '@alfalab/core-components-keyboard-focusable';
-import { AttachmentSBlackIcon, AttachmentMBlackIcon } from '@alfalab/icons-classic';
+import { AttachmentSBlackIcon } from '@alfalab/icons-classic/AttachmentSBlackIcon';
+import { AttachmentMBlackIcon } from '@alfalab/icons-classic/AttachmentMBlackIcon';
 import { pluralize } from '@alfalab/utils';
 import { truncateFilename } from './utils';
 
@@ -157,9 +158,7 @@ export const Attach = React.forwardRef<HTMLInputElement, AttachProps>(
                     disabled={disabled}
                     view={(buttonProps && buttonProps.view) || 'outlined'}
                     leftAddons={
-                        (buttonProps && buttonProps.leftAddons) || (
-                            <Icon className={styles.icon} />
-                        )
+                        (buttonProps && buttonProps.leftAddons) || <Icon className={styles.icon} />
                     }
                     onClick={handleButtonClick}
                     ref={buttonRef}

--- a/packages/bank-card/src/Component.tsx
+++ b/packages/bank-card/src/Component.tsx
@@ -2,9 +2,9 @@ import React, { useCallback, MouseEvent, ReactNode, useState, ChangeEvent, useEf
 import cn from 'classnames';
 import { MaskedInput } from '@alfalab/core-components-masked-input';
 // Дождаться иконку альфы в icons-logotype
-import { BankAlfaLColorIcon } from '@alfalab/icons-classic';
+import { BankAlfaLColorIcon } from '@alfalab/icons-classic/BankAlfaLColorIcon';
 
-import { CameraMIcon } from '@alfalab/icons-glyph';
+import { CameraMIcon } from '@alfalab/icons-glyph/CameraMIcon';
 
 import { VisaXxlIcon, MastercardLIcon, MirXxlIcon } from '@alfalab/icons-logotype';
 

--- a/packages/notification/src/Component.tsx
+++ b/packages/notification/src/Component.tsx
@@ -11,8 +11,10 @@ import React, {
 import cn from 'classnames';
 import mergeRefs from 'react-merge-refs';
 import { useSwipeable, LEFT, RIGHT, UP } from 'react-swipeable';
-import { CloseSWhiteIcon } from '@alfalab/icons-classic';
-import { CheckmarkMIcon, CrossMIcon, ExclamationMIcon } from '@alfalab/icons-glyph';
+import { CloseSWhiteIcon } from '@alfalab/icons-classic/CloseSWhiteIcon';
+import { CheckmarkMIcon } from '@alfalab/icons-glyph/CheckmarkMIcon';
+import { CrossMIcon } from '@alfalab/icons-glyph/CrossMIcon';
+import { ExclamationMIcon } from '@alfalab/icons-glyph/ExclamationMIcon';
 import { Portal } from '@alfalab/core-components-portal';
 import { Button } from '@alfalab/core-components-button';
 import { useClickOutside } from './utils';

--- a/packages/picker-button/src/field/Component.tsx
+++ b/packages/picker-button/src/field/Component.tsx
@@ -2,12 +2,10 @@ import React, { FC, SVGProps } from 'react';
 import cn from 'classnames';
 import { Button, ButtonProps } from '@alfalab/core-components-button';
 import { FieldProps as BaseFieldProps } from '@alfalab/core-components-select/src/typings';
-import {
-    ArrowDownMBlackIcon,
-    ArrowDownSBlackIcon,
-    ArrowDownMWhiteIcon,
-    ArrowDownSWhiteIcon,
-} from '@alfalab/icons-classic';
+import { ArrowDownMBlackIcon } from '@alfalab/icons-classic/ArrowDownMBlackIcon';
+import { ArrowDownSBlackIcon } from '@alfalab/icons-classic/ArrowDownSBlackIcon';
+import { ArrowDownMWhiteIcon } from '@alfalab/icons-classic/ArrowDownMWhiteIcon';
+import { ArrowDownSWhiteIcon } from '@alfalab/icons-classic/ArrowDownSWhiteIcon';
 
 import styles from './index.module.css';
 import { PickerButtonSize } from '..';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -199,11 +199,6 @@ const root = {
                     dest: `../../dist/${currentComponentName}`,
                     transform: () => createPackageJson('./esm/index.js'),
                 },
-                {
-                    src: 'package.json',
-                    dest: `../../dist/${currentComponentName}/cssm`,
-                    transform: () => createPackageJson('../esm/index.js'),
-                },
             ],
         }),
         coreComponentsRootPackageResolver({ currentPackageDir }),


### PR DESCRIPTION
- поменял импорты иконок
- удалил путь до `esm-модулей` из сборки `cssm`, так как для корректной работы нужно добавлять еще одну сборку