### PR TITLE
feat(select): add empty list placeholder prop

### DIFF
--- a/packages/input-autocomplete/src/Component.stories.mdx
+++ b/packages/input-autocomplete/src/Component.stories.mdx
@@ -72,6 +72,7 @@ export const matchOption = (option, inputValue) =>
                 onChange={handleChange}
                 onInput={handleInput}
                 value={value}
+                optionsListEmptyPlaceholder={text('optionsListEmptyPlaceholder', '')}
             />
         );
     })}

--- a/packages/input-autocomplete/src/Component.stories.mdx
+++ b/packages/input-autocomplete/src/Component.stories.mdx
@@ -72,7 +72,6 @@ export const matchOption = (option, inputValue) =>
                 onChange={handleChange}
                 onInput={handleInput}
                 value={value}
-                optionsListEmptyPlaceholder={text('optionsListEmptyPlaceholder', '')}
             />
         );
     })}

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -47,6 +47,8 @@ export const BaseSelect = forwardRef(
             label,
             placeholder,
             fieldProps = {},
+            optionsListProps = {},
+            optionsProps = {},
             valueRenderer,
             onChange,
             onOpen,
@@ -58,7 +60,7 @@ export const BaseSelect = forwardRef(
             Optgroup = () => null,
             Option = () => null,
             updatePopover,
-            optionsListEmptyPlaceholder,
+            showEmptyOptionsList = false,
         }: BaseSelectProps,
         ref,
     ) => {
@@ -230,6 +232,7 @@ export const BaseSelect = forwardRef(
             ({ option, index, ...rest }: { option: OptionShape; index: number }) => (
                 <React.Fragment key={option.key}>
                     {Option({
+                        ...(optionsProps as object),
                         ...rest,
                         innerProps: getItemProps({
                             index,
@@ -246,7 +249,7 @@ export const BaseSelect = forwardRef(
                     })}
                 </React.Fragment>
             ),
-            [Option, getItemProps, highlightedIndex, selectedItems, size],
+            [Option, getItemProps, highlightedIndex, optionsProps, selectedItems, size],
         );
 
         useEffect(() => {
@@ -280,8 +283,7 @@ export const BaseSelect = forwardRef(
             );
         }, [multiple, selectedItems, disabled, name, handleNativeSelectChange, options, menuProps]);
 
-        const needRenderOptionsList =
-            flatOptions.length > 0 || Boolean(optionsListEmptyPlaceholder);
+        const needRenderOptionsList = flatOptions.length > 0 || showEmptyOptionsList;
 
         return (
             <div
@@ -340,13 +342,13 @@ export const BaseSelect = forwardRef(
                             {needRenderOptionsList && (
                                 <div className={styles.optionsList}>
                                     <OptionsList
+                                        {...optionsListProps}
                                         flatOptions={flatOptions}
                                         highlightedIndex={highlightedIndex}
                                         open={open}
                                         size={size}
                                         options={options}
                                         Optgroup={Optgroup}
-                                        emptyPlaceholder={optionsListEmptyPlaceholder}
                                         Option={WrappedOption}
                                     />
                                 </div>

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -58,6 +58,7 @@ export const BaseSelect = forwardRef(
             Optgroup = () => null,
             Option = () => null,
             updatePopover,
+            optionsListEmptyPlaceholder,
         }: BaseSelectProps,
         ref,
     ) => {
@@ -279,6 +280,9 @@ export const BaseSelect = forwardRef(
             );
         }, [multiple, selectedItems, disabled, name, handleNativeSelectChange, options, menuProps]);
 
+        const needRenderOptionsList =
+            flatOptions.length > 0 || Boolean(optionsListEmptyPlaceholder);
+
         return (
             <div
                 {...getComboboxProps({
@@ -333,7 +337,7 @@ export const BaseSelect = forwardRef(
                             popperClassName={styles.popover}
                             update={updatePopover}
                         >
-                            {flatOptions.length > 0 && (
+                            {needRenderOptionsList && (
                                 <div className={styles.optionsList}>
                                     <OptionsList
                                         flatOptions={flatOptions}
@@ -342,6 +346,7 @@ export const BaseSelect = forwardRef(
                                         size={size}
                                         options={options}
                                         Optgroup={Optgroup}
+                                        emptyPlaceholder={optionsListEmptyPlaceholder}
                                         Option={WrappedOption}
                                     />
                                 </div>

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -48,7 +48,7 @@ export const BaseSelect = forwardRef(
             placeholder,
             fieldProps = {},
             optionsListProps = {},
-            optionsProps = {},
+            optionProps = {},
             valueRenderer,
             onChange,
             onOpen,
@@ -232,7 +232,7 @@ export const BaseSelect = forwardRef(
             ({ option, index, ...rest }: { option: OptionShape; index: number }) => (
                 <React.Fragment key={option.key}>
                     {Option({
-                        ...(optionsProps as object),
+                        ...(optionProps as object),
                         ...rest,
                         innerProps: getItemProps({
                             index,
@@ -249,7 +249,7 @@ export const BaseSelect = forwardRef(
                     })}
                 </React.Fragment>
             ),
-            [Option, getItemProps, highlightedIndex, optionsProps, selectedItems, size],
+            [Option, getItemProps, highlightedIndex, optionProps, selectedItems, size],
         );
 
         useEffect(() => {

--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -17,6 +17,7 @@ export const OptionsList = ({
     Option,
     options = [],
     Optgroup = DefaultOptgroup,
+    emptyPlaceholder,
 }: OptionsListProps) => {
     const counter = createCounter();
 
@@ -29,11 +30,19 @@ export const OptionsList = ({
         [Option, counter, size],
     );
 
-    return options.length > 0 ? (
+    if (options.length === 0 && !emptyPlaceholder) {
+        return null;
+    }
+
+    return (
         <div className={cn(styles.optionsList, styles[size])}>
             {options.map(option =>
                 isGroup(option) ? renderGroup(option) : Option({ option, index: counter() }),
             )}
+
+            {emptyPlaceholder && options.length === 0 && (
+                <div className={styles.emptyPlaceholder}>{emptyPlaceholder}</div>
+            )}
         </div>
-    ) : null;
+    );
 };

--- a/packages/select/src/components/options-list/index.module.css
+++ b/packages/select/src/components/options-list/index.module.css
@@ -19,3 +19,12 @@
 .l {
     max-height: var(--select-options-list-l-height);
 }
+
+.emptyPlaceholder {
+    padding: var(--gap-m) var(--gap-s);
+    color: var(--select-options-list-empty-placeholder-color);
+}
+
+.l .emptyPlaceholder {
+    padding: var(--gap-xl) var(--gap-m);
+}

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -25,6 +25,7 @@ export const VirtualOptionsList = ({
     options = [],
     overscan = 10,
     Optgroup = DefaultOptgroup,
+    emptyPlaceholder,
 }: VirtualOptionsList) => {
     const parentRef = useRef<HTMLDivElement>(null);
     const prevHighlightedIndex = usePrevious(highlightedIndex) || -1;
@@ -112,6 +113,10 @@ export const VirtualOptionsList = ({
                     );
                 })}
             </div>
+
+            {emptyPlaceholder && options.length === 0 && (
+                <div className={styles.emptyPlaceholder}>{emptyPlaceholder}</div>
+            )}
         </div>
     );
 };

--- a/packages/select/src/components/virtual-options-list/index.module.css
+++ b/packages/select/src/components/virtual-options-list/index.module.css
@@ -55,3 +55,8 @@
         display: none;
     }
 }
+
+.emptyPlaceholder {
+    padding: var(--gap-m) var(--gap-s);
+    color: var(--select-options-list-empty-placeholder-color);
+}

--- a/packages/select/src/components/virtual-options-list/index.module.css
+++ b/packages/select/src/components/virtual-options-list/index.module.css
@@ -60,3 +60,7 @@
     padding: var(--gap-m) var(--gap-s);
     color: var(--select-options-list-empty-placeholder-color);
 }
+
+.l .emptyPlaceholder {
+    padding: var(--gap-xl) var(--gap-m);
+}

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -172,6 +172,16 @@ export type BaseSelectProps = {
     fieldProps?: unknown;
 
     /**
+     * Пропсы, которые будут прокинуты в компонент списка
+     */
+    optionsListProps?: unknown;
+
+    /**
+     * Пропсы, которые будут прокинуты в компонент пункта меню
+     */
+    optionsProps?: unknown;
+
+    /**
      * Компонент выпадающего меню
      */
     OptionsList?: FC<OptionsListProps>;
@@ -216,9 +226,9 @@ export type BaseSelectProps = {
     updatePopover?: PopoverProps['update'];
 
     /**
-     * Будет отображаться в компоненте OptionsList, если он пустой
+     * Показывать OptionsList, если он пустой
      */
-    optionsListEmptyPlaceholder?: string;
+    showEmptyOptionsList?: boolean;
 };
 
 // TODO: использовать InputProps

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -214,6 +214,11 @@ export type BaseSelectProps = {
      * Хранит функцию, с помощью которой можно обновить положение поповера
      */
     updatePopover?: PopoverProps['update'];
+
+    /**
+     * Будет отображаться в компоненте OptionsList, если он пустой
+     */
+    optionsListEmptyPlaceholder?: string;
 };
 
 // TODO: использовать InputProps
@@ -343,6 +348,11 @@ export type OptionsListProps = {
      * Компонент группы
      */
     Optgroup?: BaseSelectProps['Optgroup'];
+
+    /**
+     * Будет отображаться, если компонент пустой
+     */
+    emptyPlaceholder?: string;
 };
 
 export type OptgroupProps = {

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -179,7 +179,7 @@ export type BaseSelectProps = {
     /**
      * Пропсы, которые будут прокинуты в компонент пункта меню
      */
-    optionsProps?: unknown;
+    optionProps?: unknown;
 
     /**
      * Компонент выпадающего меню

--- a/packages/select/src/vars.css
+++ b/packages/select/src/vars.css
@@ -13,6 +13,7 @@
     --select-options-list-s-height: 264px;
     --select-options-list-m-height: 308px;
     --select-options-list-l-height: 396px;
+    --select-options-list-empty-placeholder-color: var(--color-light-text-secondary);
     --select-option-divider-display: none;
     --select-option-divider-background: var(--color-light-border-primary);
 


### PR DESCRIPTION
Добавил в селект пропсу `optionsListEmptyPlaceholder`.
Нужна для отображения плейсхолдера `Ничего не найдено` в автокомплите.