### PR TITLE
fix(calendar): set max date to years calculation

### DIFF
--- a/packages/calendar/src/useCalendar.ts
+++ b/packages/calendar/src/useCalendar.ts
@@ -108,7 +108,7 @@ export function useCalendar({
         activeMonth,
     ]);
 
-    const years = useMemo(() => generateYears(minDate), [minDate]);
+    const years = useMemo(() => generateYears(minDate, maxDate || new Date()), [minDate, maxDate]);
 
     const setMonth = useCallback(
         (newMonth: Date) => {

--- a/packages/calendar/src/utils.ts
+++ b/packages/calendar/src/utils.ts
@@ -96,12 +96,12 @@ export function generateMonths(year: Date, options: { minMonth?: Date; maxMonth?
 }
 
 /**
- * Возвращает массив лет от текущего года и до minYear
+ * Возвращает массив лет от minYear до maxYear
  */
-export function generateYears(minYear: Date) {
+export function generateYears(minYear: Date, maxYear: Date) {
     return eachYearOfInterval({
-        start: startOfYear(minYear),
-        end: max([startOfYear(new Date()), startOfYear(minYear)]),
+        start: min([startOfYear(maxYear), startOfYear(minYear)]),
+        end: max([startOfYear(maxYear), startOfYear(minYear)]),
     }).reverse();
 }
 


### PR DESCRIPTION
# Опишите проблему
Если передать в пропсе maxDate дату года, > чем new Date(), то в списке годов следующих за текущим не появится:
https://p52.f0.n0.cdn.getcloudapp.com/items/Koul19dE/b9883993-b1ff-44b2-a439-9a96670a802d.gif?source=viewer&v=81dce36bdb03d84a7a8c81cf3cad6923

# Шаги для воспроизведения
1. Пробросить в maxDate год больший, чем текущий
2. Нажать на кнопку выбора года

# Ожидаемое поведение
Доступны все года в интервале

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10

## Смартфон (если данных нет оставте блок пустым):
 - Device: iPhone 6
 - OS: iOS 10
 - Browser: Chrome
 - Version: 65

# Дополнительная информация
Дополнительная информация
