### PR TITLE
fix(tooltip): execute tooltip's target missing callbacks

### DIFF
--- a/packages/tooltip/src/Component.test.tsx
+++ b/packages/tooltip/src/Component.test.tsx
@@ -5,6 +5,7 @@ import {
     act,
     RenderResult,
     waitForElementToBeRemoved,
+    waitFor,
 } from '@testing-library/react';
 
 import { Tooltip, TooltipProps } from './index';
@@ -174,18 +175,26 @@ describe('Click event tests', () => {
             open: true,
         });
 
-        const content = getByText(contentText);
-        const children = getByText(childrenText);
+        await waitFor(() => {
+            const content = getByText(contentText);
 
-        expect(content).toBeInTheDocument();
+            expect(content).toBeInTheDocument();
+        });
 
-        fireEvent.click(document.body);
+        await waitFor(() => {
+            fireEvent.click(document.body);
+            const content = getByText(contentText);
 
-        expect(content).toBeInTheDocument();
+            expect(content).toBeInTheDocument();
+        });
 
-        fireEvent.click(children);
+        await waitFor(() => {
+            const children = getByText(childrenText);
+            fireEvent.click(children);
+            const content = getByText(contentText);
 
-        expect(content).toBeInTheDocument();
+            expect(content).toBeInTheDocument();
+        });
     });
 
     it('should stay close if prop `open` is `false`', async () => {

--- a/packages/tooltip/src/Component.tsx
+++ b/packages/tooltip/src/Component.tsx
@@ -187,11 +187,19 @@ export const Tooltip: FC<TooltipProps> = ({
         };
     }, [close]);
 
-    const handleTargetClick = () => {
+    const handleTargetClick = (event: React.MouseEvent<HTMLElement>) => {
+        if (children.props.onClick) {
+            children.props.onClick(event);
+        }
+
         toggle();
     };
 
-    const handleMouseOver = () => {
+    const handleMouseOver = (event: React.MouseEvent<HTMLElement>) => {
+        if (children.props.onMouseOver) {
+            children.props.onMouseOver(event);
+        }
+
         clearTimeout(timer.current);
 
         timer.current = window.setTimeout(() => {
@@ -199,7 +207,11 @@ export const Tooltip: FC<TooltipProps> = ({
         }, onOpenDelay);
     };
 
-    const handleMouseOut = () => {
+    const handleMouseOut = (event: React.MouseEvent<HTMLElement>) => {
+        if (children.props.onMouseOut) {
+            children.props.onMouseOut(event);
+        }
+
         clearTimeout(timer.current);
 
         timer.current = window.setTimeout(() => {
@@ -208,6 +220,10 @@ export const Tooltip: FC<TooltipProps> = ({
     };
 
     const handleTouchStart = (event: React.TouchEvent<HTMLElement>) => {
+        if (children.props.onTouchStart) {
+            children.props.onTouchStart(event);
+        }
+
         const eventTarget = event.target as Element;
 
         clearTimeout(timer.current);


### PR DESCRIPTION
Пофиксил баг: Тултип клонирует дочерние элементы и навешивает на них обработчики (onClick/onMouseOver/onMouseOut/onTouchStart).
Если на этом элементе уже были эти обработчики, то они сейчас не вызываются.

+ поправил тест, там был warning