### PR TITLE
fix(themes): add missing variables import

### DIFF
--- a/packages/themes/src/default.css
+++ b/packages/themes/src/default.css
@@ -1,4 +1,5 @@
 @import '../../vars/src/colors.css';
+@import '../../vars/src/colors-addons.css';
 @import '../../vars/src/colors-indigo.css';
 @import '../../vars/src/shadows-indigo.css';
 @import '../../vars/src/gaps.css';


### PR DESCRIPTION
fix #442
Добавил пропущенный импорт css переменных из colors-addons.css