### PR TITLE
feat(picker-button): simplify picker-button using colorless icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "dependencies": {
         "@alfalab/data": "^0.2.0",
         "@alfalab/hooks": "^1.0.0",
-        "@alfalab/icons-classic": "^1.33.0",
+        "@alfalab/icons-classic": "^1.39.0",
         "@alfalab/icons-flag": "^1.3.0",
-        "@alfalab/icons-glyph": "^1.70.0",
-        "@alfalab/icons-logotype": "^1.4.0",
+        "@alfalab/icons-glyph": "^1.80.0",
+        "@alfalab/icons-logotype": "^1.8.0",
         "@alfalab/utils": "^0.5.0",
         "@popperjs/core": "^2.3.3",
         "alfa-ui-primitives": "^2.105.0",

--- a/packages/button/src/Component.stories.mdx
+++ b/packages/button/src/Component.stories.mdx
@@ -32,6 +32,8 @@ export const SIZES = ['xs', 's', 'm', 'l'];
         block={boolean('block', false)}
         nowrap={boolean('nowrap', false)}
         onClick={action('click')}
+        leftAddons={boolean('leftAddons', false) && <IconM />}
+        rightAddons={boolean('rightAddons', false) && <IconM />}
     >
         {text('label', 'Оплатить')}
     </Button>

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -36,24 +36,15 @@ exports[`Snapshots tests should display correctly 1`] = `
         >
           <svg
             data-test-id="picker-button-icon"
+            fill="currentColor"
             focusable="false"
             height="24"
             viewBox="0 0 24 24"
             width="24"
           >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <path
-                d="M0 24h24V0H0z"
-              />
-              <path
-                d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"
-                fill="#000"
-                fill-rule="nonzero"
-              />
-            </g>
+            <path
+              d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"
+            />
           </svg>
         </span>
       </span>
@@ -94,24 +85,15 @@ exports[`Snapshots tests should display opened correctly 1`] = `
         >
           <svg
             data-test-id="picker-button-icon"
+            fill="currentColor"
             focusable="false"
             height="24"
             viewBox="0 0 24 24"
             width="24"
           >
-            <g
-              fill="none"
-              fill-rule="evenodd"
-            >
-              <path
-                d="M0 24h24V0H0z"
-              />
-              <path
-                d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"
-                fill="#000"
-                fill-rule="nonzero"
-              />
-            </g>
+            <path
+              d="M16.074 9.646l.708.708-5.068 5.068-5.068-5.068.708-.708 4.36 4.362z"
+            />
           </svg>
         </span>
       </span>

--- a/packages/picker-button/src/field/Component.tsx
+++ b/packages/picker-button/src/field/Component.tsx
@@ -2,10 +2,8 @@ import React, { FC, SVGProps } from 'react';
 import cn from 'classnames';
 import { Button, ButtonProps } from '@alfalab/core-components-button';
 import { FieldProps as BaseFieldProps } from '@alfalab/core-components-select/src/typings';
-import { ArrowDownMBlackIcon } from '@alfalab/icons-classic/ArrowDownMBlackIcon';
-import { ArrowDownSBlackIcon } from '@alfalab/icons-classic/ArrowDownSBlackIcon';
-import { ArrowDownMWhiteIcon } from '@alfalab/icons-classic/ArrowDownMWhiteIcon';
-import { ArrowDownSWhiteIcon } from '@alfalab/icons-classic/ArrowDownSWhiteIcon';
+import { ArrowDownMIcon } from '@alfalab/icons-classic/ArrowDownMIcon';
+import { ArrowDownSIcon } from '@alfalab/icons-classic/ArrowDownSIcon';
 
 import styles from './index.module.css';
 import { PickerButtonSize } from '..';
@@ -31,12 +29,7 @@ export const Field = ({
     buttonSize = 'm',
     ...restProps
 }: FieldProps) => {
-    let Icon: FC<SVGProps<SVGSVGElement>>;
-    if (view === 'primary') {
-        Icon = buttonSize === 'xs' ? ArrowDownSWhiteIcon : ArrowDownMWhiteIcon;
-    } else {
-        Icon = buttonSize === 'xs' ? ArrowDownSBlackIcon : ArrowDownMBlackIcon;
-    }
+    const Icon: FC<SVGProps<SVGSVGElement>> = buttonSize === 'xs' ? ArrowDownSIcon : ArrowDownMIcon;
 
     return (
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore

--- a/packages/picker-button/src/field/index.module.css
+++ b/packages/picker-button/src/field/index.module.css
@@ -13,7 +13,3 @@
 .open {
     transform: rotateZ(180deg);
 }
-
-.component:not(.primary)[disabled] svg {
-    opacity: 0.3;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   resolved "https://registry.yarnpkg.com/@alfalab/hooks/-/hooks-1.0.0.tgz#b1ca13dcba6092fd628fa657866b314b29c4efa8"
   integrity sha512-kpRxkgA0tbCMeWi5u955LVM8Imu+5XXwWQjkoDTm9DIbOZU2edWuc3eW6TKWeo2NJvIi8Owt50cc7qcGZHXBLg==
 
-"@alfalab/icons-classic@^1.33.0":
-  version "1.33.0"
-  resolved "https://registry.yarnpkg.com/@alfalab/icons-classic/-/icons-classic-1.33.0.tgz#fe0be776e7327bbd449ef9d988f32fdc50688a67"
-  integrity sha512-HY+p1LaXr0U6s5SQZgmgceFRRpODcLL10iu4aQWYy+Gu/ITx84krWY6FoivP09tTIjB8chR3TJHkF1f0qGM4CQ==
+"@alfalab/icons-classic@^1.39.0":
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/@alfalab/icons-classic/-/icons-classic-1.39.0.tgz#7511cbd1119d560dcdd252302ee93d1b69efc9ea"
+  integrity sha512-v8ilhuhZbN2WkSGDxrpUamwzYz+EemtU9SGGkrL2jyqm85QRctQq6o6gVMTUoT3hj2r5oHw2fehOlDuIL3zSqA==
 
 "@alfalab/icons-classic@^1.7.0":
   version "1.7.0"
@@ -42,10 +42,20 @@
   resolved "https://registry.yarnpkg.com/@alfalab/icons-glyph/-/icons-glyph-1.71.0.tgz#c1acaddbc3795089b39fac6703449c3e170d00e1"
   integrity sha512-FA3jw4NzuBYvjoV+aRJfnE7qwl4f6r6FQg427QaRakGNNjcbsGkC6MjuglKGlwghBZDhvNaESmES2XmoNltalA==
 
+"@alfalab/icons-glyph@^1.80.0":
+  version "1.80.0"
+  resolved "https://registry.yarnpkg.com/@alfalab/icons-glyph/-/icons-glyph-1.80.0.tgz#e5bac1274dedf76d2697e39b59c378e1c3c5a9bd"
+  integrity sha512-ehl6KKp43ipTLmeSR6J7Tk7m2IwMrB4ENxXVEIUlURaOi0QmHjBvskHPEjKuus73UWSn5Lq3+sjSY7872FvwdA==
+
 "@alfalab/icons-logotype@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@alfalab/icons-logotype/-/icons-logotype-1.4.0.tgz#9122da85f55dee73d9a5ad1c90d62b07a9ff3e5e"
   integrity sha512-99dislr70hmkoWXha3aHe/2ORd03vF+zh67iXkqyiSqoHHEbJ2ydowxZhDSZBG64lgwVrhIZLEdSmyRPgpOL2w==
+
+"@alfalab/icons-logotype@^1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@alfalab/icons-logotype/-/icons-logotype-1.8.0.tgz#b81e4aa24767172af498043688c0bd853e3e743f"
+  integrity sha512-+KezJJRVQefF1vooTWgMf+kHm6MtWHf5egOhkHVmh8Js5OpPUlwZcrsEeAxAjs+1aoX/ZOglzhhMyTFPbZjxMw==
 
 "@alfalab/rollup-plugin-postcss@^3.2.0":
   version "3.2.0"


### PR DESCRIPTION
Иконки заменены на одноцветные, что позволило убрать костыль с прозрачностью svg