### PR TITLE
feat: add fieldClassName

### DIFF
--- a/packages/amount-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/amount-input/src/__snapshots__/Component.test.tsx.snap
@@ -9,10 +9,10 @@ Object {
         class="container bold"
       >
         <div
-          class="component s"
+          class="component component hasSuffix s"
         >
           <div
-            class="formControl component hasSuffix inner"
+            class="inner"
           >
             <div
               class="inputWrapper"
@@ -57,10 +57,10 @@ Object {
       class="container bold"
     >
       <div
-        class="component s"
+        class="component component hasSuffix s"
       >
         <div
-          class="formControl component hasSuffix inner"
+          class="inner"
         >
           <div
             class="inputWrapper"
@@ -162,10 +162,10 @@ Object {
         class="container bold"
       >
         <div
-          class="component s"
+          class="component component hasSuffix s"
         >
           <div
-            class="formControl component hasSuffix inner"
+            class="inner"
           >
             <div
               class="inputWrapper"
@@ -209,10 +209,10 @@ Object {
         class="container bold filled"
       >
         <div
-          class="component s"
+          class="component component suffixVisible hasSuffix s"
         >
           <div
-            class="formControl component suffixVisible hasSuffix inner filled"
+            class="inner filled"
           >
             <div
               class="inputWrapper"
@@ -260,10 +260,10 @@ Object {
       class="container bold filled"
     >
       <div
-        class="component s"
+        class="component component suffixVisible hasSuffix s"
       >
         <div
-          class="formControl component suffixVisible hasSuffix inner filled"
+          class="inner filled"
         >
           <div
             class="inputWrapper"

--- a/packages/bank-card/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/bank-card/src/__snapshots__/Component.test.tsx.snap
@@ -31,10 +31,10 @@ exports[`BankCard Snapshots tests should match snapshots 1`] = `
           </svg>
         </div>
         <div
-          class="component s block hasRightAddons"
+          class="component filled s block hasRightAddons"
         >
           <div
-            class="formControl filled inner filled hasLabel"
+            class="inner filled hasLabel"
           >
             <div
               class="inputWrapper"
@@ -140,10 +140,10 @@ exports[`BankCard Snapshots tests should match snapshots 2`] = `
           </svg>
         </div>
         <div
-          class="component s block hasRightAddons"
+          class="component filled s block hasRightAddons"
         >
           <div
-            class="formControl filled inner filled hasLabel"
+            class="inner filled hasLabel"
           >
             <div
               class="inputWrapper"
@@ -247,10 +247,10 @@ exports[`BankCard Snapshots tests should match snapshots 3`] = `
           </svg>
         </div>
         <div
-          class="component s block hasRightAddons"
+          class="component filled s block hasRightAddons"
         >
           <div
-            class="formControl filled inner filled hasLabel"
+            class="inner filled hasLabel"
           >
             <div
               class="inputWrapper"
@@ -354,10 +354,10 @@ exports[`BankCard Snapshots tests should match snapshots 4`] = `
           </svg>
         </div>
         <div
-          class="component s block hasRightAddons"
+          class="component filled s block hasRightAddons"
         >
           <div
-            class="formControl filled inner filled hasLabel"
+            class="inner filled hasLabel"
           >
             <div
               class="inputWrapper"

--- a/packages/calendar-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-input/src/__snapshots__/Component.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`CalendarInput Display tests should match snapshot 1`] = `
       class="component s block hasRightAddons"
     >
       <div
-        class="formControl inner"
+        class="inner"
       >
         <div
           class="inputWrapper"

--- a/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-range/src/__snapshots__/Component.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
         class="component s block hasRightAddons"
       >
         <div
-          class="formControl inner"
+          class="inner"
         >
           <div
             class="inputWrapper"
@@ -575,7 +575,7 @@ exports[`CalendarRange Display tests should match snapshot 1`] = `
           class="component s block hasRightAddons"
         >
           <div
-            class="formControl inner"
+            class="inner"
           >
             <div
               class="inputWrapper"

--- a/packages/form-control/src/Component.test.tsx
+++ b/packages/form-control/src/Component.test.tsx
@@ -58,14 +58,14 @@ describe('FormControl', () => {
     });
 
     describe('Classes tests', () => {
-        it('should set `className` class to inner', () => {
+        it('should set `className` class to root', () => {
             const className = 'test-class';
             const dataTestId = 'test-id';
             const { getByTestId } = render(
                 <FormControl className={className} dataTestId={dataTestId} />,
             );
 
-            expect(getByTestId(dataTestId).firstElementChild).toHaveClass(className);
+            expect(getByTestId(dataTestId)).toHaveClass(className);
         });
 
         it('should set `labelClassName` class to label', () => {

--- a/packages/form-control/src/Component.tsx
+++ b/packages/form-control/src/Component.tsx
@@ -65,6 +65,11 @@ export type FormControlProps = HTMLAttributes<HTMLDivElement> & {
     className?: string;
 
     /**
+     * Дополнительный класс для поля
+     */
+    fieldClassName?: string;
+
+    /**
      * Дополнительный класс для лейбла
      */
     labelClassName?: string;
@@ -91,6 +96,7 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
             block = false,
             size = 's',
             className,
+            fieldClassName,
             labelClassName,
             addonsClassName,
             disabled,
@@ -113,7 +119,7 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
         return (
             <div
                 data-test-id={dataTestId}
-                className={cn(styles.component, styles[size], {
+                className={cn(styles.component, className, styles[size], {
                     [styles.block]: block,
                     [styles.hasLeftAddons]: leftAddons,
                     [styles.hasRightAddons]: rightAddons || error,
@@ -121,7 +127,7 @@ export const FormControl = React.forwardRef<HTMLDivElement, FormControlProps>(
             >
                 <div
                     {...restProps}
-                    className={cn(className, styles.inner, {
+                    className={cn(fieldClassName, styles.inner, {
                         [styles.focused]: focused,
                         [styles.disabled]: disabled,
                         [styles.filled]: filled,

--- a/packages/input/src/Component.test.tsx
+++ b/packages/input/src/Component.test.tsx
@@ -66,8 +66,14 @@ describe('Input', () => {
     });
 
     describe('Classes tests', () => {
-        it('should set `className` class to form-control inner', () => {
+        it('should set `className` class to form-control wrapper', () => {
             const { container } = render(<Input className='test-class' />);
+
+            expect(container.querySelector('.test-class')).toHaveClass('component');
+        });
+
+        it('should set `fieldClassName` class to form-control field', () => {
+            const { container } = render(<Input fieldClassName='test-class' />);
 
             expect(container.querySelector('.test-class')).toHaveClass('inner');
         });
@@ -123,29 +129,25 @@ describe('Input', () => {
     });
 
     describe('when component is controlled', () => {
-        it('should set `filled` and filledClassName classes when value passed', () => {
+        it('should filledClassName classes when value passed', () => {
             const filledClassName = 'custom-filled-class';
             const { container } = render(
                 <Input value='some value' filledClassName={filledClassName} />,
             );
 
-            const inner = container.querySelector('.inner');
+            const component = container.querySelector(`.${filledClassName}`);
 
-            expect(inner).toHaveClass('filled');
-            expect(inner).toHaveClass(filledClassName);
+            expect(component).toBeInTheDocument();
         });
 
-        it('should not set `filled` and filledClassName classes if the value is empty', () => {
+        it('should not set filledClassName classes if the value is empty', () => {
             const filledClassName = 'custom-filled-class';
             const { container } = render(<Input value='' filledClassName={filledClassName} />);
 
-            const inner = container.querySelector('.inner');
-
-            expect(inner).not.toHaveClass('filled');
-            expect(inner).not.toHaveClass(filledClassName);
+            expect(container.querySelector(`.${filledClassName}`)).not.toBeInTheDocument();
         });
 
-        it('should unset `filled` and filledClassName classes if the value becomes empty', () => {
+        it('should unset filledClassName classes if the value becomes empty', () => {
             const filledClassName = 'custom-filled-class';
             const { container, rerender } = render(
                 <Input value='some value' filledClassName={filledClassName} />,
@@ -153,10 +155,7 @@ describe('Input', () => {
 
             rerender(<Input value='' filledClassName={filledClassName} />);
 
-            const inner = container.querySelector('.inner');
-
-            expect(inner).not.toHaveClass('filled');
-            expect(inner).not.toHaveClass(filledClassName);
+            expect(container.querySelector(`.${filledClassName}`)).not.toBeInTheDocument();
         });
 
         it('should show clear button only if input has value', () => {
@@ -198,32 +197,28 @@ describe('Input', () => {
     });
 
     describe('when component is uncontrolled', () => {
-        it('should set `filled` and filledClassName classes when defaultValue passed', () => {
+        it('should filledClassName classes when defaultValue passed', () => {
             const filledClassName = 'custom-filled-class';
             const { container } = render(
                 <Input defaultValue='some value' filledClassName={filledClassName} />,
             );
 
-            const inner = container.querySelector('.inner');
+            const component = container.querySelector(`.${filledClassName}`);
 
-            expect(inner).toHaveClass('filled');
-            expect(inner).toHaveClass(filledClassName);
+            expect(component).toBeInTheDocument();
         });
 
-        it('should not set `filled` and filledClassName classes if the value is empty', () => {
+        it('should not filledClassName classes if the value is empty', () => {
             const filledClassName = 'custom-filled-class';
             const { container } = render(<Input filledClassName={filledClassName} />);
 
-            const inner = container.querySelector('.inner');
-
-            expect(inner).not.toHaveClass('filled');
-            expect(inner).not.toHaveClass(filledClassName);
+            expect(container.querySelector(`.${filledClassName}`)).not.toBeInTheDocument();
         });
 
-        it('should unset `filled` and filledClassName classes if value becomes empty', async () => {
+        it('should unset filledClassName classes if value becomes empty', async () => {
             const dataTestId = 'test-id';
             const filledClassName = 'custom-filled-class';
-            const { getByTestId } = render(
+            const { container, getByTestId } = render(
                 <Input
                     defaultValue='some value'
                     dataTestId={dataTestId}
@@ -239,8 +234,8 @@ describe('Input', () => {
             input.blur();
 
             expect(input.value).toBe('');
-            expect(input).not.toHaveClass('filled');
-            expect(input).not.toHaveClass(filledClassName);
+
+            expect(container.querySelector(`.${filledClassName}`)).not.toBeInTheDocument();
         });
 
         it('should show clear button only if input has value', async () => {

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -96,6 +96,11 @@ export type InputProps = Omit<
     className?: string;
 
     /**
+     * Дополнительный класс для поля
+     */
+    fieldClassName?: string;
+
+    /**
      * Дополнительный класс инпута
      */
     inputClassName?: string;
@@ -158,13 +163,14 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             type = 'text',
             block = false,
             bottomAddons,
-            className,
             dataTestId,
             clear = false,
             disabled,
             error,
             success,
             hint,
+            className,
+            fieldClassName,
             inputClassName,
             labelClassName,
             addonsClassName,
@@ -284,15 +290,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         return (
             <FormControl
                 ref={wrapperRef}
-                className={cn(
-                    styles.formControl,
-                    className,
-                    focused && focusedClassName,
-                    filled && filledClassName,
-                    {
-                        [styles.focusVisible]: focusVisible,
-                    },
-                )}
+                className={cn(className, focused && focusedClassName, filled && filledClassName)}
+                fieldClassName={cn(fieldClassName, {
+                    [styles.focusVisible]: focusVisible,
+                })}
                 labelClassName={labelClassName}
                 addonsClassName={addonsClassName}
                 size={size}

--- a/packages/input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/input/src/__snapshots__/Component.test.tsx.snap
@@ -9,7 +9,7 @@ Object {
         class="component s"
       >
         <div
-          class="formControl inner filled"
+          class="inner filled"
         >
           <div
             class="inputWrapper"
@@ -34,7 +34,7 @@ Object {
       class="component s"
     >
       <div
-        class="formControl inner filled"
+        class="inner filled"
       >
         <div
           class="inputWrapper"

--- a/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
+++ b/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`IntlPhoneInput should match snapshot 1`] = `
 <div>
   <div
-    class="component m hasLeftAddons"
+    class="component m m hasLeftAddons"
   >
     <div
-      class="formControl m inner filled"
+      class="inner filled"
     >
       <div
         class="addons leftAddons addons"

--- a/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/masked-input/src/__snapshots__/Component.test.tsx.snap
@@ -9,7 +9,7 @@ Object {
         class="component s"
       >
         <div
-          class="formControl inner"
+          class="inner"
         >
           <div
             class="inputWrapper"
@@ -34,7 +34,7 @@ Object {
       class="component s"
     >
       <div
-        class="formControl inner"
+        class="inner"
       >
         <div
           class="inputWrapper"

--- a/packages/phone-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/phone-input/src/__snapshots__/Component.test.tsx.snap
@@ -9,7 +9,7 @@ Object {
         class="component s"
       >
         <div
-          class="formControl inner"
+          class="inner"
         >
           <div
             class="inputWrapper"
@@ -34,7 +34,7 @@ Object {
       class="component s"
     >
       <div
-        class="formControl inner"
+        class="inner"
       >
         <div
           class="inputWrapper"

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -34,6 +34,7 @@ export const TagList: FC<FieldProps & FormControlProps & TagListOwnProps> = ({
     Arrow,
     innerProps,
     className,
+    fieldClassName,
     value,
     autocomplete,
     label,
@@ -97,12 +98,12 @@ export const TagList: FC<FieldProps & FormControlProps & TagListOwnProps> = ({
             ref={wrapperRef}
             onFocus={handleFocus}
             onBlur={handleBlur}
-            className={cn(styles.component, styles[size])}
+            className={cn(className, styles.component, styles[size])}
         >
             <FormControl
                 {...restProps}
                 ref={innerProps.ref}
-                className={cn(className, styles.field, {
+                fieldClassName={cn(fieldClassName, styles.field, {
                     [styles.focusVisible]: focusVisible,
                 })}
                 block={true}

--- a/packages/select/src/components/field/Component.tsx
+++ b/packages/select/src/components/field/Component.tsx
@@ -22,8 +22,8 @@ export const Field = ({
     valueRenderer = joinOptions,
     Arrow,
     innerProps,
-    className,
     dataTestId,
+    fieldClassName,
     ...restProps
 }: BaseFieldProps & FormControlProps) => {
     const [focused, setFocused] = useState(false);
@@ -47,7 +47,7 @@ export const Field = ({
             onBlur={handleBlur}
         >
             <FormControl
-                className={cn(className, styles.field, {
+                fieldClassName={cn(styles.field, fieldClassName, {
                     [styles.hasLabel]: label,
                     [styles.disabled]: disabled,
                     [styles.focusVisible]: focusVisible,

--- a/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/slider-input/src/__snapshots__/Component.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`SliderInput should match snapshot 1`] = `
     class="component s"
   >
     <div
-      class="component s block"
+      class="component input s block"
     >
       <div
-        class="formControl input inner"
+        class="inner"
       >
         <div
           class="inputWrapper"

--- a/packages/textarea/src/Component.test.tsx
+++ b/packages/textarea/src/Component.test.tsx
@@ -29,12 +29,10 @@ describe('Textarea', () => {
     });
 
     describe('Classes tests', () => {
-        it('should set `className` class to form-control inner', () => {
+        it('should set `className` class to form-control wrapper', () => {
             const { container } = render(<Textarea className='test-class' />);
 
-            const inner = container.querySelector('.test-class');
-
-            expect(inner).toHaveClass('inner');
+            expect(container.querySelector('.test-class')).toHaveClass('component');
         });
 
         it('should set `textareaClassName` class to textarea', () => {

--- a/packages/textarea/src/Component.tsx
+++ b/packages/textarea/src/Component.tsx
@@ -74,6 +74,11 @@ export type TextareaProps = Omit<
     className?: string;
 
     /**
+     * Дополнительный класс для поля
+     */
+    fieldClassName?: string;
+
+    /**
      * Дополнительный класс textarea
      */
     textareaClassName?: string;
@@ -127,6 +132,7 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
             size = 's',
             block = false,
             bottomAddons,
+            fieldClassName,
             className,
             dataTestId,
             disabled,
@@ -229,7 +235,8 @@ export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 
         return (
             <FormControl
-                className={cn(className, {
+                className={cn(className)}
+                fieldClassName={cn(fieldClassName, {
                     [styles.focusVisible]: focusVisible,
                 })}
                 size={size}

--- a/packages/with-suffix/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/with-suffix/src/__snapshots__/Component.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`withSuffix Snapshots tests should match snapshot 1`] = `
 <div>
   <div
-    class="component s"
+    class="component suffixVisible hasSuffix s"
   >
     <div
-      class="formControl suffixVisible hasSuffix inner filled"
+      class="inner filled"
     >
       <div
         class="inputWrapper"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9968618/104456283-7ed2ff80-55b9-11eb-9f21-0304667f1e28.png)

Привел инпут к единообразию с остальными компонентами. Лучше это сейчас сделать, пока еще нет активного использования либы

BREAKING CHANGE: может затронуть кастомную стилизацию контролов
