### PR TITLE
fix(select): add options-list padding for click theme

### DIFF
--- a/packages/themes/src/mixins/select/click.css
+++ b/packages/themes/src/mixins/select/click.css
@@ -10,7 +10,8 @@
     --select-arrow-background: url('http://alfabank.st/icons/glyph_chevron-down_m.svg');
 
     /* options list */
-
+    --select-options-list-top-padding: 8px;
+    --select-options-list-bottom-padding: 8px;
     --select-option-divider-display: block;
 
     /* checkmark */


### PR DESCRIPTION
# Опишите проблему
Небольшое несоответствие дизайну

# Шаги для воспроизведения
Открыть выпадающий список у селекта

# Ожидаемое поведение
Отступы у выпадающего списка для темы клик должны быть по 8 px

ui кит клика:
https://www.figma.com/file/KlFOLLkKO8rtvvQE3RXuhq/Click-Library?node-id=8706%3A291