### PR TITLE
fix: adds semantic release configs again

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,7 +3,7 @@ name: Create new library packages
 on:
   push:
     branches:
-      - test-test
+      - master
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Build app
         run: yarn && yarn build
 
@@ -26,13 +26,11 @@ jobs:
       - name: Publish root package
         run: |
           yarn semantic-release
-          sh ${{ github.workspace }}/bin/publish-root-package.sh
         env:
           GITHUB_TOKEN: ${{ secrets.PERMISSION_GITHUB_TOKEN }}
 
       - name: Publish separate packages
         run: |
           yarn semantic-release-lerna
-          yarn lerna publish from-package --yes
         env:
           GITHUB_TOKEN: ${{ secrets.PERMISSION_GITHUB_TOKEN }}

--- a/bin/publish-root-package.sh
+++ b/bin/publish-root-package.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# выхожу, если одна из команд завершилась неудачно
-set -e
-
-# получаем последний актуальный git тег
-current_version=`git describe --tags $(git rev-list --tags --max-count=1) | sed -e "s/^v//"`
-
-yarn publish dist --no-git-tag-version --new-version $current_version

--- a/packages/release.config.js
+++ b/packages/release.config.js
@@ -3,16 +3,7 @@ module.exports = {
         '@semantic-release/commit-analyzer',
         '@semantic-release/release-notes-generator',
         '@semantic-release/changelog',
-        [
-            '@semantic-release/npm',
-            { pkgRoot: './dist' },
-        ],
-        [
-            '@semantic-release/npm',
-            { npmPublish: false },
-        ],
-        '@semantic-release/git',
-        '@semantic-release/github',
+        ['@semantic-release/npm', { pkgRoot: './' }],
     ],
     branches: ['master'],
     repositoryUrl: 'https://github.com/alfa-laboratory/core-components',


### PR DESCRIPTION
# Опишите проблему
Проблема в том что надо руками постоянно выпускать релизы, хотя это по идее должно происходить на каждое изменеие мастера и версия должня высчитываться исходя из сообщений коммитов.

ПР решает эту проблему, а именно semantic-release сам меняет версии в package.json и пушит в npm, так же пушит все подпокеты с верными версиями в npm.

Для примера как работает можно посмотреть [тестовый репозиторий,](https://github.com/IBelyaev/core-components-test) так же могу дать права чтобы руками там поменять код и посмотреть, как все работает.
_Чтобы получить доступ - пишите мне в слак._