### PR TITLE
feat(button): transparent view

### DIFF
--- a/packages/button/src/Component.stories.mdx
+++ b/packages/button/src/Component.stories.mdx
@@ -9,7 +9,7 @@ import IconS from '@alfalab/icons-glyph/FlashCircleSIcon';
 import { Button } from './Component';
 import { name, version } from '../package.json';
 
-export const VIEWS = ['primary', 'secondary', 'outlined', 'filled', 'link', 'ghost'];
+export const VIEWS = ['primary', 'secondary', 'outlined', 'filled', 'transparent', 'link', 'ghost'];
 export const SIZES = ['xs', 's', 'm', 'l'];
 
 
@@ -71,6 +71,9 @@ import { Button } from '@alfalab/core-components-button';
             </Col>
             <Col>
                 <Button view='filled'>Filled</Button>
+            </Col>
+            <Col>
+                <Button view='transparent'>Transparent</Button>
             </Col>
             <Col>
                 <Button view='link'>Link</Button>
@@ -147,6 +150,22 @@ import { Button } from '@alfalab/core-components-button';
             {SIZES.map(size => (
                 <Col key={size}>
                     <Button size={size} view="filled">
+                        Кнопка
+                    </Button>
+                </Col>
+            ))}
+        </Row>
+    </Container>
+</Preview>
+
+- <b>Transparent</b>. Кнопка с прозрачностью.
+
+<Preview>
+    <Container>
+        <Row>
+            {SIZES.map(size => (
+                <Col key={size}>
+                    <Button size={size} view="transparent">
                         Кнопка
                     </Button>
                 </Col>
@@ -255,10 +274,7 @@ import { Button } from '@alfalab/core-components-button';
     {React.createElement(() => {
         const [loading, setLoading] = React.useState({
             primary: false,
-            secondary: false,
-            outlined: false,
-            link: false,
-            ghost: false
+            secondary: false
         });
         const handleClick = (buttonName) => {
             setLoading({...loading, [buttonName]: true});

--- a/packages/button/src/Component.tsx
+++ b/packages/button/src/Component.tsx
@@ -11,7 +11,7 @@ export type ComponentProps = {
     /**
      * Тип кнопки
      */
-    view?: 'primary' | 'secondary' | 'outlined' | 'filled' | 'link' | 'ghost';
+    view?: 'primary' | 'secondary' | 'outlined' | 'filled' | 'transparent' | 'link' | 'ghost';
 
     /**
      * Слот слева

--- a/packages/button/src/index.module.css
+++ b/packages/button/src/index.module.css
@@ -13,8 +13,12 @@
     --button-secondary-color: var(--color-light-text-primary);
     --button-secondary-base-bg-color: var(--color-light-specialbg-component);
     --button-secondary-base-border-color: transparent;
-    --button-secondary-hover-bg-color: color-mod(var(--button-secondary-base-bg-color) shade(7%));
-    --button-secondary-active-bg-color: color-mod(var(--button-secondary-base-bg-color) shade(15%));
+    --button-secondary-hover-bg-color: color-mod(
+        var(--button-secondary-base-bg-color) blenda(black 7%)
+    );
+    --button-secondary-active-bg-color: color-mod(
+        var(--button-secondary-base-bg-color) blenda(black 15%)
+    );
     --button-secondary-disabled-bg-color: var(--color-light-specialbg-component);
     --button-secondary-disabled-border-color: transparent;
     --button-secondary-disabled-color: color-mod(var(--color-light-text-primary) alpha(30%));
@@ -163,7 +167,7 @@ a.loading {
     }
 
     &:active {
-        background-color: color-mod(var(--color-light-specialbg-component) shade(7%));
+        background-color: color-mod(var(--color-light-specialbg-component) blenda(black 7%));
     }
 }
 
@@ -172,11 +176,24 @@ a.loading {
     background-color: var(--color-light-specialbg-component);
 
     &:hover {
-        background-color: color-mod(var(--color-light-specialbg-component) shade(7%));
+        background-color: color-mod(var(--color-light-specialbg-component) blenda(black 7%));
     }
 
     &:active {
-        background-color: color-mod(var(--color-light-specialbg-component) shade(15%));
+        background-color: color-mod(var(--color-light-specialbg-component) blenda(black 15%));
+    }
+}
+
+.transparent {
+    color: var(--color-light-text-primary);
+    background-color: color-mod(var(--color-light-bg-primary-inverted) alpha(10%));
+
+    &:hover {
+        background-color: color-mod(var(--color-light-bg-primary-inverted) alpha(20%));
+    }
+
+    &:active {
+        background-color: color-mod(var(--color-light-bg-primary-inverted) alpha(40%));
     }
 }
 
@@ -190,7 +207,7 @@ a.loading {
     }
 
     &:active {
-        background-color: color-mod(var(--color-light-specialbg-component) shade(7%));
+        background-color: color-mod(var(--color-light-specialbg-component) blenda(black 7%));
     }
 }
 
@@ -260,6 +277,16 @@ a.loading {
         &.loading {
             color: var(--color-light-text-primary);
             background-color: var(--color-light-specialbg-component);
+        }
+    }
+
+    &.transparent {
+        color: color-mod(var(--color-light-text-primary) alpha(30%));
+        background-color: color-mod(var(--color-light-bg-primary-inverted) alpha(3%));
+
+        &.loading {
+            color: var(--color-light-text-primary);
+            background-color: color-mod(var(--color-light-bg-primary-inverted) alpha(10%));
         }
     }
 

--- a/packages/themes/src/mixins/button/corp.css
+++ b/packages/themes/src/mixins/button/corp.css
@@ -15,7 +15,9 @@
     --button-secondary-base-bg-color: transparent;
     --button-secondary-base-border-color: var(--color-light-border-tertiary-inverted);
     --button-secondary-hover-bg-color: var(--color-light-specialbg-component);
-    --button-secondary-active-bg-color: color-mod(var(--color-light-specialbg-component) shade(7%));
+    --button-secondary-active-bg-color: color-mod(
+        var(--color-light-specialbg-component) blenda(black 7%)
+    );
     --button-secondary-disabled-bg-color: transparent;
     --button-secondary-disabled-border-color: color-mod(
         var(--color-light-border-tertiary-inverted) alpha(30%)


### PR DESCRIPTION
Во-первых, это красиво.

Дополнительный вид [с полупрозрачным фоном](https://www.figma.com/file/KlFOLLkKO8rtvvQE3RXuhq/Click-Library?node-id=14001%3A44930).

Также фиксит hover/active для secondary/filled кнопок после изменения цвета specialbg-component (для полупрозрачного цвета нужен blenda вместо shade).