### PR TITLE
fix(select): fix safari overflow bug

### DIFF
--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -28,6 +28,7 @@
     border-radius: var(--select-options-list-border-radius);
     background: var(--select-option-background);
     overflow: hidden;
+    will-change: transform;
 }
 
 .nativeSelect {


### PR DESCRIPTION
# Опишите проблему
Проблема сафари overflow: hidden + border-radius

# Шаги для воспроизведения
Открыть сафари
Открыть селект с большим кол-вом опций

# Ожидаемое поведение
Увидеть, что, из-за бага сафари у option-list нет скругления. Потому как overflow: hidden + border-radius не работают в сафари, как ожидается

Ожидаемый        | Фактический
:---------------:|:--------------------|
** ![image](https://user-images.githubusercontent.com/12587757/106161310-de273700-6197-11eb-906f-67ec46739a31.png) ** | ** ![image](https://user-images.githubusercontent.com/12587757/106161227-c5b71c80-6197-11eb-9d90-0f2239ab5614.png) ** | 

Фиксится при помощи transform: translateZ(0) либо will-change: transform для современных браузеров. 