### PR TITLE
fix(select): option active state

### DIFF
--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -254,7 +254,6 @@ export const BaseSelect = forwardRef(
                             index,
                             item: option,
                             disabled: option.disabled,
-                            onMouseDown: (event: MouseEvent) => event.preventDefault(),
                         }),
                         index,
                         option,

--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -23,6 +23,8 @@ export const OptionsList = ({
 }: OptionsListProps) => {
     const counter = createCounter();
 
+    const handleMouseDown = useCallback(event => event.preventDefault(), []);
+
     const renderGroup = useCallback(
         (group: GroupShape) => (
             <Optgroup label={group.label} key={group.label} size={size}>
@@ -37,7 +39,12 @@ export const OptionsList = ({
     }
 
     return (
-        <div className={cn(styles.optionsList, styles[size], className)} data-test-id={dataTestId}>
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+            className={cn(styles.optionsList, styles[size], className)}
+            onMouseDown={handleMouseDown}
+            data-test-id={dataTestId}
+        >
             {options.map(option =>
                 isGroup(option) ? renderGroup(option) : Option({ option, index: counter() }),
             )}

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import React, { useRef, useEffect, useMemo } from 'react';
+import React, { useRef, useEffect, useMemo, useCallback } from 'react';
 import cn from 'classnames';
 import { useVirtual } from 'react-virtual';
 import { OptionsListProps, GroupShape, OptionShape } from '../../typings';
@@ -37,6 +37,8 @@ export const VirtualOptionsList = ({
         parentRef,
         overscan,
     });
+
+    const handleMouseDown = useCallback(event => event.preventDefault(), []);
 
     // Сколл к выбранному пункту при открытии меню
     useEffect(() => {
@@ -87,9 +89,11 @@ export const VirtualOptionsList = ({
     }, [options]);
 
     return (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <div
             className={cn(styles.virtualOptionsList, styles[size], className)}
             ref={parentRef}
+            onMouseDown={handleMouseDown}
             data-test-id={dataTestId}
         >
             <div


### PR DESCRIPTION
Фикс :active состояния у пунктов меню в FF

Немного не в том месте отменял блюр.
Материал делают так же:
https://github.com/mui-org/material-ui/blob/b6eb3ad95b51f5d9e753ed6f52185fdcf7fd44ac/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js#L987