### PR TITLE
ci: change ci workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,24 +15,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: yarn --pure-lockfile
+
       - name: Build app
-        run: yarn && yarn build
+        run: yarn build
         env:
           BUILD_CONCURRENCY: 5
 
-      - name: Set NPM Token Action
+      - name: Set NPM Token
         uses: filipstefansson/set-npm-token-action@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish root package
-        run: |
-          yarn semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERMISSION_GITHUB_TOKEN }}
+      - name: Set Github credentials
+        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          name: 'semantic-release-bot'
+          email: 'semantic-release-bot@martynus.net'
+          token: '${{ secrets.PERMISSION_GITHUB_TOKEN }}'
 
-      - name: Publish separate packages
-        run: |
-          yarn semantic-release-lerna
+      - name: Publish
+        run: yarn pub:ci
         env:
           GITHUB_TOKEN: ${{ secrets.PERMISSION_GITHUB_TOKEN }}

--- a/bin/publish-ci.sh
+++ b/bin/publish-ci.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# Релизим рут-пакет с помощью semantic-release
+semantic_output=$(yarn semantic-release)
+
+# Выводим логи семантика
+echo $semantic_output
+
+# Проеряем, что semantic-release зарелизил рут-пакет (пока не знаю, как это можно сделать по-другому)
+if [[ $semantic_output =~ "Publishing version" ]]
+then
+    git remote set-url origin https://semantic-release-bot:$GITHUB_TOKEN@github.com/alfa-laboratory/core-components.git
+    git checkout master
+    git pull origin master --rebase
+    git fetch --tags
+
+    if [ -z $(lerna changed) ]
+    then
+        echo "There are no relevant changes, so no new versions are released."
+    else
+        lerna version --conventional-commits --no-commit-hooks --yes
+        git push origin master
+        lerna publish from-git --yes
+    fi
+else
+    exit 0
+fi

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
         "release": "standard-version --no-verify --releaseCommitMessageFormat \"chore: release\"",
         "postbuild": "yarn purgecss",
         "purgecss": "./bin/purgecss.sh",
-        "semantic-release-lerna": "lerna exec --concurrency 5 -- yarn semantic-release -e semantic-release-monorepo --tag-format='${LERNA_PACKAGE_NAME}@\\${version}'",
         "pub:patch": "RELEASE_TYPE=\"patch\" ./bin/publish.sh",
         "pub:minor": "RELEASE_TYPE=\"minor\" ./bin/publish.sh",
-        "pub:major": "RELEASE_TYPE=\"major\" ./bin/publish.sh"
+        "pub:major": "RELEASE_TYPE=\"major\" ./bin/publish.sh",
+        "pub:ci": "./bin/publish-ci.sh"
     },
     "browserslist": {
         "production": [


### PR DESCRIPTION
Немного поменял процесс публикации:

- рутовый пакет релизится через `semantic-release`
- подпакеты релизятся через `lerna`
