### PR TITLE
fix(select): min width bug

### DIFF
--- a/packages/select/src/components/base-select/index.module.css
+++ b/packages/select/src/components/base-select/index.module.css
@@ -2,7 +2,6 @@
 @import '../../vars.css';
 
 .component {
-    min-width: 240px;
     width: max-content;
     position: relative;
     outline: 0;
@@ -48,7 +47,6 @@
 
 .block {
     width: 100%;
-    min-width: auto;
 }
 
 /* width: max-content; fix for IE */


### PR DESCRIPTION
# Проблема
Не корректно работало обрезание текста для _option_. Слишком большой контент с `white-space: nowrap; ` выезжал за границы контейнера (формы например). Особенность: если на _option_ висит `display: grid;`, то такого эффекта не наблюдается.

# Ожидаемое поведение
Текст обрезается, всё отображается корректно.

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
 <img width="200" alt="good-select" src="https://user-images.githubusercontent.com/9527123/108338453-55744780-71e7-11eb-82b3-5526a806affc.png"> | <img width="200" alt="bad-select" src="https://user-images.githubusercontent.com/9527123/108338613-848ab900-71e7-11eb-8db2-9543659bd3c1.png">


## Десктоп (если данных нет оставьте блок пустым):
 - OS: MacOS
 - Browser: Chrome