### PR TITLE
fix(select): recalc height on options changed

### DIFF
--- a/packages/select/src/components/options-list/Component.tsx
+++ b/packages/select/src/components/options-list/Component.tsx
@@ -39,6 +39,7 @@ export const OptionsList = ({
         visibleOptions,
         listRef,
         open,
+        invalidate: options.length,
     });
 
     if (options.length === 0 && !emptyPlaceholder) {

--- a/packages/select/src/components/virtual-options-list/Component.tsx
+++ b/packages/select/src/components/virtual-options-list/Component.tsx
@@ -76,7 +76,7 @@ export const VirtualOptionsList = ({
 
     useVisibleOptions({
         visibleOptions,
-        invalidate: rowVirtualizer.virtualItems.length,
+        invalidate: listRef.current,
         listRef,
         styleTargetRef: parentRef,
         open,

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -96,7 +96,7 @@ type useVisibleOptionsArgs = {
     /**
      * Позволяет вызвать пересчет высоты
      */
-    invalidate?: number;
+    invalidate?: unknown;
 };
 
 export function useVisibleOptions({


### PR DESCRIPTION
Пересчитываем высоту меню, если кол-во пунктов меню изменилось. Актуально для автокомплита