### PR TITLE
fix(select-with-tags): changed styles and icons

### DIFF
--- a/packages/select-with-tags/src/__snapshots__/component.test.tsx.snap
+++ b/packages/select-with-tags/src/__snapshots__/component.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`SelectWithTags Display tests should match snapshot 1`] = `
               class="input"
             >
               <div
-                class="contentWrapper"
+                class="contentWrapper contentWrapperVertical"
               >
                 <input
                   aria-autocomplete="list"
@@ -82,7 +82,7 @@ exports[`SelectWithTags Display tests should match snapshot with selected tags 1
               class="input"
             >
               <div
-                class="contentWrapper hasTags"
+                class="contentWrapper contentWrapperVertical hasTags"
               >
                 <button
                   class="component xs checked tag"
@@ -95,14 +95,15 @@ exports[`SelectWithTags Display tests should match snapshot with selected tags 1
                       H
                       <svg
                         class="tagCross"
-                        fill="currentColor"
                         focusable="false"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
+                        height="18"
+                        version="1"
+                        viewBox="0 0 18 18"
+                        width="18"
                       >
                         <path
-                          d="M10.586 12L8 14.5 9.5 16l2.5-2.586L14.5 16l1.5-1.5-2.586-2.5L16 9.5 14.5 8 12 10.586 9.5 8 8 9.5l2.586 2.5z"
+                          d="M14.646 2.646L9 8.293 3.354 2.646l-.708.708L8.293 9l-5.647 5.646.708.708L9 9.707l5.646 5.647.708-.708L9.707 9l5.647-5.646z"
+                          fill="#FFF"
                         />
                       </svg>
                     </span>
@@ -119,14 +120,15 @@ exports[`SelectWithTags Display tests should match snapshot with selected tags 1
                       Li
                       <svg
                         class="tagCross"
-                        fill="currentColor"
                         focusable="false"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
+                        height="18"
+                        version="1"
+                        viewBox="0 0 18 18"
+                        width="18"
                       >
                         <path
-                          d="M10.586 12L8 14.5 9.5 16l2.5-2.586L14.5 16l1.5-1.5-2.586-2.5L16 9.5 14.5 8 12 10.586 9.5 8 8 9.5l2.586 2.5z"
+                          d="M14.646 2.646L9 8.293 3.354 2.646l-.708.708L8.293 9l-5.647 5.646.708.708L9 9.707l5.646 5.647.708-.708L9.707 9l5.647-5.646z"
+                          fill="#FFF"
                         />
                       </svg>
                     </span>
@@ -143,14 +145,15 @@ exports[`SelectWithTags Display tests should match snapshot with selected tags 1
                       Na
                       <svg
                         class="tagCross"
-                        fill="currentColor"
                         focusable="false"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
+                        height="18"
+                        version="1"
+                        viewBox="0 0 18 18"
+                        width="18"
                       >
                         <path
-                          d="M10.586 12L8 14.5 9.5 16l2.5-2.586L14.5 16l1.5-1.5-2.586-2.5L16 9.5 14.5 8 12 10.586 9.5 8 8 9.5l2.586 2.5z"
+                          d="M14.646 2.646L9 8.293 3.354 2.646l-.708.708L8.293 9l-5.647 5.646.708.708L9 9.707l5.646 5.647.708-.708L9.707 9l5.647-5.646z"
+                          fill="#FFF"
                         />
                       </svg>
                     </span>

--- a/packages/select-with-tags/src/component.stories.mdx
+++ b/packages/select-with-tags/src/component.stories.mdx
@@ -61,13 +61,14 @@ export const matchOption = (option, inputValue) =>
                     collapseTagList={boolean('collapseTagList', true)}
                     moveInputToNewLine={boolean('moveInputToNewLine', true)}
                     options={options}
+                    multiple={boolean('multiple', true)}
                     block={boolean('block', true)}
+                    closeOnSelect={boolean('closeOnSelect', false)}
                     size={select('size', ['s', 'm', 'l'], 'l')}
                     disabled={boolean('disabled', false)}
                     error={text('error', '')}
                     success={boolean('success', false)}
                     hint={text('hint', '')}
-                    Arrow={boolean('Arrow', false) ? Arrow : undefined}
                     circularNavigation={boolean('circularNavigation', false)}
                     placeholder={text('placeholder', 'Элемент')}
                     label={text('label', '')}

--- a/packages/select-with-tags/src/component.tsx
+++ b/packages/select-with-tags/src/component.tsx
@@ -30,6 +30,7 @@ export const SelectWithTags = forwardRef<HTMLInputElement, SelectWithTagsProps>(
             allowUnselect = true,
             collapseTagList = false,
             moveInputToNewLine = true,
+            multiple = true,
             emptyListPlaceholder = 'Ничего не найдено',
             transformCollapsedTagText,
             transformTagText,
@@ -117,7 +118,7 @@ export const SelectWithTags = forwardRef<HTMLInputElement, SelectWithTagsProps>(
                 Optgroup={Optgroup}
                 OptionsList={OptionsList}
                 Arrow={Arrow}
-                multiple={true}
+                multiple={multiple}
                 updatePopover={updatePopover}
                 allowUnselect={allowUnselect}
                 showEmptyOptionsList={true}

--- a/packages/select-with-tags/src/components/tag-list/component.tsx
+++ b/packages/select-with-tags/src/components/tag-list/component.tsx
@@ -201,6 +201,9 @@ export const TagList: FC<FieldProps & FormControlProps & TagListOwnProps> = ({
             >
                 <div
                     className={cn(styles.contentWrapper, {
+                        [styles.contentWrapperVertical]: Boolean(
+                            !collapseTagList || isShowMoreEnabled,
+                        ),
                         [styles.hasLabel]: Boolean(label),
                         [styles.hasTags]: selectedMultiple.length > 0,
                     })}

--- a/packages/select-with-tags/src/components/tag-list/index.module.css
+++ b/packages/select-with-tags/src/components/tag-list/index.module.css
@@ -16,8 +16,18 @@
 }
 
 .component.l .contentWrapper {
-    padding-left: var(--gap-m);
-    padding-right: var(--gap-m);
+    padding-top: var(--gap-l);
+    padding-bottom: var(--gap-l);
+}
+
+.component.m .contentWrapper {
+    padding-top: var(--gap-m);
+    padding-bottom: var(--gap-m);
+}
+
+.component.s .contentWrapper {
+    padding-top: var(--gap-s);
+    padding-bottom: var(--gap-s);
 }
 
 .component .contentWrapper {

--- a/packages/select-with-tags/src/components/tag-list/index.module.css
+++ b/packages/select-with-tags/src/components/tag-list/index.module.css
@@ -103,12 +103,17 @@
 }
 
 .component.s .label {
-    top: 4px;
-    left: 16px;
+    top: 6px;
+    left: 12px;
 }
 
 .component.m .label {
-    top: 6px;
+    top: 8px;
+    left: 12px;
+}
+
+.component.l .label {
+    top: 14px;
     left: 16px;
 }
 

--- a/packages/select-with-tags/src/components/tag-list/index.module.css
+++ b/packages/select-with-tags/src/components/tag-list/index.module.css
@@ -1,18 +1,28 @@
 @import '../../../../vars/src/index.css';
 
+.component.l .contentWrapperVertical {
+    padding-top: var(--gap-l);
+    padding-bottom: var(--gap-l);
+}
+
+.component.m .contentWrapperVertical {
+    padding-top: var(--gap-s);
+    padding-bottom: var(--gap-s);
+}
+
+.component.s .contentWrapperVertical {
+    padding-top: var(--gap-xs);
+    padding-bottom: var(--gap-xs);
+}
+
 .component.l .contentWrapper {
-    padding: var(--gap-l) var(--gap-m);
-}
-
-.component.m .contentWrapper {
-    padding: var(--gap-m) var(--gap-m);
-}
-
-.component.s .contentWrapper {
-    padding: var(--gap-s) var(--gap-m);
+    padding-left: var(--gap-m);
+    padding-right: var(--gap-m);
 }
 
 .component .contentWrapper {
+    padding-left: var(--gap-s);
+    padding-right: var(--gap-s);
     display: flex;
     flex-wrap: wrap;
     width: 100%;

--- a/packages/select-with-tags/src/components/tag/component.tsx
+++ b/packages/select-with-tags/src/components/tag/component.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import cn from 'classnames';
+import { CloseSWhiteIcon } from '@alfalab/icons-classic';
 import { Tag as CoreTag } from '@alfalab/core-components-tag';
-import { CrossCompactMIcon } from '@alfalab/icons-glyph/CrossCompactMIcon';
 import { TagComponent } from '../../types';
 import styles from './index.module.css';
 
@@ -26,10 +26,12 @@ export const Tag: TagComponent = ({
             className={cn(styles.tag, { [styles.tagNoClose]: !handleDeleteTag })}
             {...props}
         >
-            <span className={styles.tagContentWrap}>
+            <span
+                className={cn(styles.tagContentWrap, { [styles.collapseButton]: !handleDeleteTag })}
+            >
                 {content}
                 {handleDeleteTag && (
-                    <CrossCompactMIcon onClick={handleClick} className={styles.tagCross} />
+                    <CloseSWhiteIcon className={styles.tagCross} onClick={handleClick} />
                 )}
             </span>
         </CoreTag>

--- a/packages/select-with-tags/src/components/tag/index.module.css
+++ b/packages/select-with-tags/src/components/tag/index.module.css
@@ -22,11 +22,11 @@
 
 .tagNoClose {
     padding-right: var(--gap-m);
-    color: var(--color-blue-link-mobile);
+    color: var(--color-light-text-link);
 
     &:hover:not(:disabled):not(:active) {
         background-color: var(--tag-background-color-hover);
-        color: var(--color-blue-link-mobile);
+        color: var(--color-light-text-link);
         border-color: var(--tag-border-color-disabled);
     }
 }

--- a/packages/select-with-tags/src/components/tag/index.module.css
+++ b/packages/select-with-tags/src/components/tag/index.module.css
@@ -22,6 +22,13 @@
 
 .tagNoClose {
     padding-right: var(--gap-m);
+    color: var(--color-blue-link-mobile);
+
+    &:hover:not(:disabled):not(:active) {
+        background-color: var(--tag-background-color-hover);
+        color: var(--color-blue-link-mobile);
+        border-color: var(--tag-border-color-disabled);
+    }
 }
 
 .tagContentWrap {
@@ -34,7 +41,8 @@
 
 .tagCross {
     height: 100%;
-    padding-right: var(--gap-xs);
+    margin-left: var(--gap-xs);
+    margin-right: var(--gap-m);
 
     &:hover {
         opacity: 0.7;

--- a/packages/select-with-tags/src/types.ts
+++ b/packages/select-with-tags/src/types.ts
@@ -13,7 +13,7 @@ export type TagComponent = FC<TagProps>;
 
 export type SelectWithTagsProps = Omit<
     BaseSelectProps,
-    'Field' | 'nativeSelect' | 'multiple' | 'autocomplete' | 'selected' | 'onChange'
+    'Field' | 'nativeSelect' | 'autocomplete' | 'selected' | 'onChange'
 > & {
     /**
      * Значение поля ввода


### PR DESCRIPTION
# Опишите проблему
Немного фиксов которые не соответствуют макетам
Дока [Figma](https://www.figma.com/file/uGndMZufgvqxaNQTaNTEjG/B2B-Web-Components?node-id=7094%3A55904)

# Чек лист
- [x] Обновлены снэпшоты
- [x] Возможность выбора single/multiple
- [x] TagList - поправил отступы для размеров s,m,l, согласно доке
- [x] TagList - поправил багу которая увеличивала высоту инпута(например S с 48px до 56px) после добавления в список хотя бы одного тэга
- [x] Tag - поправил отступы и заменил иконку(удаления тэга) согласно доке
- [x] Tag - добавил стили для тэга который collapse согласно доке

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** <img width="377" alt="Screenshot 2021-02-25 at 00 21 07" src="https://user-images.githubusercontent.com/26882552/109073658-5f260f80-76ff-11eb-9c10-651acaa7f128.png">  ** | ** <img width="377" alt="Screenshot 2021-02-25 at 00 22 07" src="https://user-images.githubusercontent.com/26882552/109073753-81b82880-76ff-11eb-86b5-e0fc6c205acb.png">
    **|

