### PR TITLE
feat(confirmation): add disable sms repeat property

### DIFF
--- a/packages/confirmation/src/component.stories.mdx
+++ b/packages/confirmation/src/component.stories.mdx
@@ -52,6 +52,7 @@ import { Select } from '../../select/src/Component';
         const phone = '+7 000 000 00 42';
         const countdownDuration = 10000;
         const requiredCharAmount = number('requiredCharAmount', 5);
+        const disableSmsRepeat = boolean('disableSmsRepeat', false);
         return (
             <div>
                 <Select
@@ -89,6 +90,7 @@ import { Select } from '../../select/src/Component';
                                 onInputChange={({ code }) => setCode('success', code)}
                                 alignContent={alignContent}
                                 requiredCharAmount={requiredCharAmount}
+                                disableSmsRepeat={disableSmsRepeat}
                             />
                         </div>
                     }

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -120,6 +120,11 @@ export type ConfirmationProps = {
     alignContent?: ContentAlign;
 
     /**
+     * Управление возможностью перезапросить код
+     */
+    disableSmsRepeat?: boolean;
+
+    /**
      * Обработчик события завершения ввода кода подписания
      */
     onInputFinished: ({ code }: { code: string }) => void;
@@ -174,6 +179,7 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
             buttonErrorText = 'Понятно',
             buttonRetryText = 'Попробовать заново',
             alignContent = 'left',
+            disableSmsRepeat = false,
             onInputFinished,
             onSmsRetryClick,
             onActionWithFatalError,
@@ -197,7 +203,8 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
 
         const nonFatalError = errorIsFatal ? '' : errorText;
 
-        const shouldShowHintLink = countdownFinished && !codeChecking && retries > 0;
+        const shouldShowHintLink =
+            disableSmsRepeat || (countdownFinished && !codeChecking && retries > 0);
 
         const inputRef = useRef<HTMLInputElement>(null);
 
@@ -269,6 +276,7 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                         codeCheckingText={codeCheckingText}
                         codeSendingText={codeSendingText}
                         alignContent={alignContent}
+                        disableSmsRepeat={disableSmsRepeat}
                         onInputFinished={onInputFinished}
                         onInputChange={onInputChange}
                         onSmsRetryClick={handleSmsRetryClick}
@@ -328,7 +336,6 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                         </div>
 
                         <Button
-                            className={styles.repeatButton}
                             size='s'
                             view='secondary'
                             block={true}

--- a/packages/confirmation/src/components/countdown/component.tsx
+++ b/packages/confirmation/src/components/countdown/component.tsx
@@ -48,6 +48,7 @@ export type CountdownProps = {
     phone?: string;
     className?: string;
     alignContent: string;
+    disableSmsRepeat: boolean;
     onCountdownFinished?: () => void;
     onRepeatSms: (event: MouseEvent) => void;
 };
@@ -57,6 +58,7 @@ export const Countdown: FC<CountdownProps> = ({
     phone,
     hasPhoneMask = true,
     alignContent,
+    disableSmsRepeat,
     onRepeatSms,
     onCountdownFinished,
     className,
@@ -97,16 +99,34 @@ export const Countdown: FC<CountdownProps> = ({
     }, [duration, onCountdownFinished]);
 
     useEffect(() => {
-        start.current = Date.now();
-
-        requestId.current = window.requestAnimationFrame(updateProgress);
+        if (!disableSmsRepeat) {
+            start.current = Date.now();
+            requestId.current = window.requestAnimationFrame(updateProgress);
+        }
 
         return () => {
-            window.cancelAnimationFrame(requestId.current);
+            if (requestId.current) {
+                window.cancelAnimationFrame(requestId.current);
+                requestId.current = 0;
+            }
         };
-    }, [updateProgress, repeatSmsButtonShow]);
+    }, [updateProgress, repeatSmsButtonShow, disableSmsRepeat]);
 
     const progress = timePassed / duration;
+
+    if (disableSmsRepeat) {
+        return (
+            <div className={cn(styles.component, styles[alignContent], className)}>
+                {phone && (
+                    <div>
+                        Код отправлен на
+                        {' '}
+                        {hasPhoneMask ? formatMaskedPhone(phone) : phone}
+                    </div>
+                )}
+            </div>
+        );
+    }
 
     return (
         <div className={cn(styles.component, styles[alignContent], className)}>

--- a/packages/confirmation/src/components/sign-confirmation/component.tsx
+++ b/packages/confirmation/src/components/sign-confirmation/component.tsx
@@ -28,6 +28,7 @@ export type SignConfirmationProps = {
     hasSmsCountdown: boolean;
     inputRef: MutableRefObject<HTMLInputElement | null>;
     alignContent: ContentAlign;
+    disableSmsRepeat: boolean;
     onInputFinished: ({ code }: { code: string }) => void;
     onInputChange: ({ code }: { code: string }) => void;
     onSmsRetryClick: (event: React.MouseEvent) => void;
@@ -53,6 +54,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
     codeCheckingText,
     codeSendingText,
     alignContent,
+    disableSmsRepeat,
     onInputFinished,
     onInputChange,
     onSmsRetryClick,
@@ -132,6 +134,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
                         hasPhoneMask={hasPhoneMask}
                         className={styles.countdown}
                         alignContent={alignContent}
+                        disableSmsRepeat={disableSmsRepeat}
                         onRepeatSms={onSmsRetryClick}
                         onCountdownFinished={onCountdownFinished}
                     />


### PR DESCRIPTION
Добавляю свойство для отключения возможности перезапроса кода смс. Необходимо, когда количество попыток повторного запроса исчерпано. 

Тестов не нашел.