### PR TITLE
fix(select-with-tags): remove pointer events from placeholder

### DIFF
--- a/packages/select-with-tags/src/components/tag-list/index.module.css
+++ b/packages/select-with-tags/src/components/tag-list/index.module.css
@@ -77,6 +77,7 @@
     min-height: 28px;
     padding-left: var(--gap-2xs);
     color: var(--color-light-text-tertiary);
+    pointer-events: none;
 }
 
 .addons {


### PR DESCRIPTION
# Опишите проблему
Не открывается селект с тэгами при клике на внутреннее поле

# Шаги для воспроизведения
1. Выбрать autocomplete=false
2. Потыкать на плейсхолдер

# Ожидаемое поведение
Селект должен открываться\закрываться

# Дополнительная информация
При autocomplete=false, плейсхолдер рендерится отдельным элементом и [условие](https://github.com/alfa-laboratory/core-components/blob/master/packages/select-with-tags/src/components/tag-list/component.tsx#L114) работает не совсем корректно

