### PR TITLE
fix: fix types importing in root package

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         "@types/react-dom": "^16.9.5",
         "@typescript-eslint/eslint-plugin": "^2.23.0",
         "@typescript-eslint/parser": "^2.23.0",
-        "@wessberg/rollup-plugin-ts": "^1.3.6",
+        "@wessberg/rollup-plugin-ts": "^1.3.8",
         "arui-presets-lint": "4.1.1",
         "arui-presets-ts": "^5.0.0",
         "axios": "^0.21.0",

--- a/tools/rollup/core-components-typings-resolver.js
+++ b/tools/rollup/core-components-typings-resolver.js
@@ -1,7 +1,9 @@
 import globby from 'globby';
 import path from 'path';
 
-import { checkOrCreateDir, readFile, requireRegExp, writeFile } from './common';
+import { checkOrCreateDir, readFile, writeFile } from './common';
+
+const importTypesRegexp = /((?:from |import\()['"])@alfalab\/core-components-(.+?)(['"])/;
 
 async function transformTypings(source, rootDir) {
     const rootAbsDir = path.resolve(rootDir);
@@ -11,12 +13,12 @@ async function transformTypings(source, rootDir) {
 
     let matches;
 
-    while ((matches = requireRegExp.exec(fileContent))) {
+    while ((matches = importTypesRegexp.exec(fileContent))) {
         const componentName = matches[2];
 
         const componentRelativePath = path.relative(path.dirname(sourceAbs), componentName);
 
-        fileContent = fileContent.replace(requireRegExp, `$1${componentRelativePath}$3`);
+        fileContent = fileContent.replace(importTypesRegexp, `$1${componentRelativePath}$3`);
     }
 
     let dest = path.join(rootAbsDir, source.replace('dist/', ''));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4690,7 +4690,7 @@
     semver "^7.3.2"
     ua-parser-js "^0.7.22"
 
-"@wessberg/rollup-plugin-ts@^1.3.6":
+"@wessberg/rollup-plugin-ts@^1.3.8":
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/@wessberg/rollup-plugin-ts/-/rollup-plugin-ts-1.3.8.tgz#90c8d091006fa83c117449ba51a49ec07f0b5797"
   integrity sha512-mqAk8CS5VbeE1eMRwbBkrVWqrqDxRJEWfxPHFyncsoamoazZ7iJ4Fke7tYBki+x25dw0rkN6l3VgtICM7o//cw==


### PR DESCRIPTION
Поменял регулярку для поиска импортов типов в рут-пакете. 
Протестить сборку можно `@alfalab/core-components@13.1.1-beta.0`