### PR TITLE
feat(select): add options-list width

### DIFF
--- a/packages/select/src/Component.stories.mdx
+++ b/packages/select/src/Component.stories.mdx
@@ -419,6 +419,39 @@ import { Select } from '@alfalab/core-components-select';
     })}
 </Preview>
 
+## Ширина выпадающего меню
+
+По умолчанию ширину выпадающего меню задает контент пунктов.
+Если контент слишком длинный, то может понадобиться изменить это поведение.
+
+Это можно сделать с помощью свойства `optionsListWidth='field'` — в этом случае ширина выпадающего меню будет равна ширине поля, а лишний контент обрежется.
+
+<Preview>
+    {React.createElement(() => {
+        const LongContent = ({ text }) => (
+            <span style={{ whiteSpace: 'nowrap' }} title={text}>
+                {text}
+            </span>
+        );
+        const longOptions = [
+            { key: '1', content: <LongContent text='Великий Новгород' /> },
+            { key: '2', content: <LongContent text='Гусь-Хрустальный' /> },
+            { key: '3', content: <LongContent text='Каменск-Шахтинский' /> },
+            { key: '4', content: <LongContent text='Очень длинное название' /> },
+        ];
+        return (
+            <div style={{ width: 160 }}>
+                <Select
+                    block={true}
+                    label='Города'
+                    options={longOptions}
+                    optionsListWidth='field'
+                />
+            </div>
+        );
+    })}
+</Preview>
+
 ## Группы
 
 Группированный селект

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -43,6 +43,7 @@ export const BaseSelect = forwardRef(
             defaultOpen = false,
             popoverPosition = 'bottom-start',
             preventFlip = true,
+            optionsListWidth = 'content',
             name,
             id,
             selected,
@@ -373,7 +374,9 @@ export const BaseSelect = forwardRef(
                                 {...menuProps}
                                 className={cn(optionsListClassName, styles.optionsList)}
                                 style={{
-                                    minWidth: optionsListMinWidth,
+                                    [optionsListWidth === 'field'
+                                        ? 'width'
+                                        : 'minWidth']: optionsListMinWidth,
                                 }}
                             >
                                 <OptionsList

--- a/packages/select/src/components/option/index.module.css
+++ b/packages/select/src/components/option/index.module.css
@@ -86,6 +86,11 @@
     color: var(--select-option-disabled-color);
 }
 
+.content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* IE min-height fix */
 
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -111,6 +111,12 @@ export type BaseSelectProps = {
     block?: boolean;
 
     /**
+     * Управляет шириной выпадающего меню.
+     * Ширину определяет контент, либо ширина равна ширине поля
+     */
+    optionsListWidth?: 'content' | 'field';
+
+    /**
      * Лейбл поля
      */
     label?: ReactNode;


### PR DESCRIPTION
Добавил возможность управлять шириной выпадающего меню. 
Оказалось, что это частый кейс, когда нужно обрезать пункты меню по ширине поля

![image](https://user-images.githubusercontent.com/9968618/111517081-bb5fda80-8765-11eb-91bc-5a8ba36ddd19.png)
