### PR TITLE
chore: sprite testing

### DIFF
--- a/.storybook/public/global.css
+++ b/.storybook/public/global.css
@@ -774,6 +774,7 @@ div.lib-welcome {
     white-space: normal;
 }
 
-#explorerкомпоненты--screenshots {
+#explorerкомпоненты--screenshots,
+#explorerкомпоненты--screenshots-sprite {
     display: none;
 }

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffe04d778857205547071ef81a4207a49e2a1eb441fcdb14448c1f052a91be9f
-size 1583

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98fc05489d90b589682dff0a133a33357d04b1d5b5d9116e9ffea4ad493f35d5
-size 1631

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:efb8906dfac1c0d8271c750ea0586f02135291637342264c022b0f5eec23c485
-size 1737

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8aa81ad3d9b4428c119ba67ba3f2244a48a20d525a2aab1215863ab413f9a441
-size 1628

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-4-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-4-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bb2173808e18d87cd59a762be384df3a9bfb281469955a45db0144fa7a28732f
-size 1511

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-5-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-disabled-view-5-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8adfb2dd64e6f61069e2bbfb5b1f761618c3857660e6e3c072b1bfd65cfd5c3
-size 1508

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-loading-view-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-loading-view-0-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3466722dc8b7380ecf4a324061f0bf462bf760de8c0df732fee557a9eb5c0bc
-size 569
+oid sha256:f69eacc097e7302cd2487a8b2145c6c790f228ae81678a1fc7ce2574e93a9d74
+size 577

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-loading-view-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-loading-view-3-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0df220b79a3bce63659fdcde3f6e089bcbc3d5bed8f7eb3ad8b9f1bbe855e13
-size 546
+oid sha256:096cc604b7378b461d940b8b458eb3c5b722f309c4a356b79659b81c4bec9dd8
+size 541

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50f9fc2948ee910da97b77f306685469152da004d8ee263a2bb180f9647c9a6e
-size 1657

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f1c8406b0a4b0cbbd6afaf4b022e8e4ebfc0f0830d4315ce20bbf562875a9cc
-size 1805

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:664171c7ba91e998a0a1807dc3a94420c51db9995efeb401bfdeedf841f7bc65
-size 1805

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-0-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:172c47bdbc96db45f09db2ba684c5ebda82cc9a1b67d19ac8400cbfb66e9026a
-size 1972

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1361d420bad59c14d0ea4dfb2f01963edd609a6ee8e3ff9b088bb9725226f5ff
-size 1720

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0696ba573fd12606588f47211ddbdf5549ae567402aa66b99233e6ea1ee30dea
-size 1891

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:19fad61f267786dbe2baa6191013f4dcf07b65d3128f85809e933b99160ab321
-size 1891

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-1-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fa0c1663a11bb3485ac04ea4e236b9f23787fa2a6b2ed8e0d60d4781949e4c8
-size 2046

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a49a2ec9ea0c4effe206a994c6e9f64f05479ca043789a2834ce8ad12eee62e9
-size 1769

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8fccba6aa2e6a4352b0ba4a047c4cd9409b8def03058389b172fc72921054bd5
-size 1929

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d3aaa79cc7200258c7a52549583435cf99c96f9a9b1d2b544a3145ef602baf2d
-size 1929

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-2-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d83ae6977d0914f6b8f5b88078770702e48c7f633fb00a4a8208d1584d09be0d
-size 2097

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1977a5d6e03810cde1acdfa1c30597a2419876dc9a6a3a91affa2a40ce854b51
-size 1718

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14f02eced321bb6d343af8421478b8d1b6bb3246550f30079079a42902a5d649
-size 1890

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c96bcf7584c92eba31e021b57c142677f78145af47f1a240987dcfa801ec28d6
-size 1890

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-3-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fa0c1663a11bb3485ac04ea4e236b9f23787fa2a6b2ed8e0d60d4781949e4c8
-size 2046

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b9a1fb6a83373cbf92ca7e0227c286580d7478c79ab0092a179db251186dd7fc
-size 1516

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:315331c3b80a440e4d280634ceeb5b778523531b50693ab3a495b222881e804a
-size 1666

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ddc034e4d08b46e61241281bb8f4460e5e474fec16d635d5a7d62adcbba80019
-size 1666

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-4-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b4fa0a1b0cc237822c84ecc6c23ac9a262a2b1de788c041f49e603b28853364
-size 1858

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-0-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-0-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba355fa0429ebd4310d97668ea8981539057bbd4dc2132bf0ad2d426281c2941
-size 1517

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-1-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-1-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e96a7bf9500cdf8a24596ed209b16ec867294adcc15026a09fe6217debd4c1a3
-size 1661

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-2-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-2-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e96a7bf9500cdf8a24596ed209b16ec867294adcc15026a09fe6217debd4c1a3
-size 1661

--- a/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-3-snap.png
+++ b/packages/button/src/__image_snapshots__/button-screenshots-views-and-sizes-view-5-size-3-snap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d45ec73804eb81ea0795d5103338d374027d61913d42b725b7be237c95313e72
-size 1853

--- a/packages/button/src/__image_snapshots__/button-views-sizes-disabled-sprite-snap.png
+++ b/packages/button/src/__image_snapshots__/button-views-sizes-disabled-sprite-snap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea3b4b1d323f425793b2389677e1bbeb11617f5c93a782ed00e90efaa7ca9dff
+size 94911

--- a/packages/button/src/component.screenshots.test.tsx
+++ b/packages/button/src/component.screenshots.test.tsx
@@ -3,6 +3,7 @@ import {
     setupScreenshotTesting,
     customSnapshotIdentifier,
     generateTestCases,
+    createSpriteStorybookUrl,
 } from '../../screenshot-utils';
 
 const screenshotTesting = setupScreenshotTesting({
@@ -15,33 +16,26 @@ const screenshotTesting = setupScreenshotTesting({
 const clip = { x: 0, y: 0, width: 200, height: 100 };
 
 describe(
-    'Button | screenshots views and sizes',
+    'Button | views, sizes, disabled',
     screenshotTesting({
-        cases: generateTestCases({
-            componentName: 'Button',
-            knobs: {
-                children: 'Оплатить',
-                view: ['primary', 'secondary', 'outlined', 'filled', 'link', 'ghost'],
-                size: ['xs', 's', 'm', 'l'],
-            },
-        }),
-
-        screenshotOpts: { clip },
-    }),
-);
-
-describe(
-    'Button | screenshots views and disabled',
-    screenshotTesting({
-        cases: generateTestCases({
-            componentName: 'Button',
-            knobs: {
-                children: 'Оплатить',
-                view: ['primary', 'secondary', 'outlined', 'filled', 'link', 'ghost'],
-                disabled: true,
-            },
-        }),
-        screenshotOpts: { clip },
+        cases: [
+            [
+                'sprite',
+                createSpriteStorybookUrl({
+                    componentName: 'Button',
+                    size: { width: 200, height: 80 },
+                    knobs: {
+                        children: 'Оплатить',
+                        view: ['primary', 'secondary', 'outlined', 'filled', 'link', 'ghost'],
+                        size: ['xs', 's', 'm', 'l'],
+                        disabled: [false, true],
+                    },
+                }),
+            ],
+        ],
+        screenshotOpts: {
+            fullPage: true,
+        },
     }),
 );
 

--- a/packages/screenshot-utils/createStorybookUrl.ts
+++ b/packages/screenshot-utils/createStorybookUrl.ts
@@ -19,6 +19,14 @@ export type CreateStorybookUrlParams = {
     knobs?: Knobs;
 };
 
+export type CreateSpriteStorybookUrlParams = {
+    url?: string;
+    packageName?: string;
+    componentName: string;
+    knobs?: KnobsCombinations;
+    size?: { width: number; height: number };
+};
+
 export function createStorybookUrl({
     url = STORYBOOK_URL,
     componentName,
@@ -36,4 +44,18 @@ export function createStorybookUrl({
     }
 
     return `${url}?id=компоненты--${packageName}${knobsQuery}`;
+}
+
+export function createSpriteStorybookUrl({
+    url = STORYBOOK_URL,
+    componentName,
+    packageName = snakeToCamel(componentName),
+    knobs = {},
+    size,
+}: CreateSpriteStorybookUrlParams) {
+    const sizeParam = size ? `&height=${size.height}&width=${size.width}` : '';
+
+    return `${url}?id=компоненты--screenshots-sprite&package=${packageName}&component=${componentName}${sizeParam}&knobs=${JSON.stringify(
+        knobs,
+    )}`;
 }

--- a/packages/screenshot-utils/screenshots-story/sprite.stories.module.css
+++ b/packages/screenshot-utils/screenshots-story/sprite.stories.module.css
@@ -1,0 +1,20 @@
+@import '../../themes/src/default.css';
+
+.container {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+.item {
+    margin: var(--gap-2xs);
+    border-radius: 3px;
+}
+
+.title {
+    max-width: 240px;
+    display: block;
+    font-size: 9px;
+    color: var(--color-light-text-secondary);
+    margin-bottom: var(--gap-xs);
+}

--- a/packages/screenshot-utils/screenshots-story/sprite.stories.tsx
+++ b/packages/screenshot-utils/screenshots-story/sprite.stories.tsx
@@ -1,0 +1,54 @@
+import React, { CSSProperties } from 'react';
+import { combosToProps, generateCombos } from '../utils';
+import { getComponent } from './components';
+import { getQueryParam } from './utils';
+
+import styles from './sprite.stories.module.css';
+
+const propsToTitle = props => {
+    const { children, ...restProps } = props;
+    return JSON.stringify(restProps).replace(/[{}"]/g, '');
+};
+
+export const ScreenshotsSprite = () => {
+    const knobs = getQueryParam('knobs') ? JSON.parse(getQueryParam('knobs')) : {};
+
+    const combos = generateCombos(Object.values(knobs).map(v => (Array.isArray(v) ? v : [v])));
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const ids = combos.map(combo => combo.map(([_, valueIndex]) => valueIndex).join('-'));
+
+    const propsList = combosToProps(combos, Object.keys(knobs));
+
+    const packageName = getQueryParam('package');
+    const componentName = getQueryParam('component');
+    const Component = getComponent(packageName, componentName);
+
+    const componentStyles: CSSProperties = {};
+    componentStyles.width = +getQueryParam('width') || undefined;
+    componentStyles.height = +getQueryParam('height') || undefined;
+
+    if (!Component) return null;
+
+    return (
+        <div className={styles.container}>
+            {propsList.map((props, index) => (
+                <div
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={index}
+                    className={styles.item}
+                >
+                    <span className={styles.title}>{propsToTitle(props)}</span>
+
+                    <div id={ids[index]} style={componentStyles}>
+                        <Component {...props} />
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default {
+    title: 'Компоненты',
+};

--- a/packages/screenshot-utils/screenshots-story/utils.ts
+++ b/packages/screenshot-utils/screenshots-story/utils.ts
@@ -1,6 +1,6 @@
 import qs from 'querystring';
 
-const queryParams = qs.parse(document.location.search);
+export const queryParams = qs.parse(document.location.search);
 
 export const getQueryParam = (param: string) => queryParams[param] as string;
 

--- a/packages/screenshot-utils/utils.ts
+++ b/packages/screenshot-utils/utils.ts
@@ -17,6 +17,20 @@ export function generateCombos<T>(
     return result;
 }
 
+export function combosToProps(combos: Array<Array<[unknown, number]>>, names: string[]) {
+    return combos.map(
+        combo =>
+            combo.reduce(
+                (props, [value], nameIndex) => ({
+                    ...props,
+                    [names[nameIndex]]: value,
+                }),
+                [],
+            ),
+        [],
+    );
+}
+
 export function snakeToCamel(str: string) {
     return str.toLowerCase().replace(/([-_][a-z])/g, (group: string) =>
         group


### PR DESCRIPTION
Добавил возможность для группового тестирования компонентов — рисуем все варианты на одной странице за один проход и получаем один спрайт.

Пример диффа (у xs кнопки изменился font-size)

![image](https://user-images.githubusercontent.com/9968618/112831933-4a8dbc00-909d-11eb-9fc1-8f3f0a0afb45.png)
