### PR TITLE
fix(select-with-tags): changed includes method for IE11 support

### DIFF
--- a/packages/select-with-tags/src/utils/match.ts
+++ b/packages/select-with-tags/src/utils/match.ts
@@ -3,7 +3,7 @@ import { GroupShape, OptionShape, isGroup } from '@alfalab/core-components-selec
 import { OptionMatcher, SelectWithTagsProps } from '../types';
 
 const defaultMatch: OptionMatcher = (option, inputValue) =>
-    option.value.toLowerCase().includes((inputValue || '').toLowerCase());
+    option.value.toLowerCase().indexOf((inputValue || '').toLowerCase(), 0) !== -1;
 
 const optionsIsGroupShapes = (options: SelectWithTagsProps['options']): options is GroupShape[] => {
     const item = options[0];


### PR DESCRIPTION
# Опишите проблему
Пофиксил недоступное свойство объекта(includes) в браузере IE11 

Дока
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes

## Десктоп:
 - OS: Windows
 - Browser: IE
 - Version: 11
