### PR TITLE
fix(calendar-input): allow to pass all props via calendarProps

### DIFF
--- a/packages/calendar-input/src/Component.test.tsx
+++ b/packages/calendar-input/src/Component.test.tsx
@@ -319,6 +319,28 @@ describe('CalendarInput', () => {
             expect(nonDisabledDays[nonDisabledDays.length - 1]).toHaveTextContent('25');
         });
 
+        it('should set min and max dates to calendar via calendarProps', () => {
+            const defaultMonth = new Date('November 01, 2020 00:00:00').getTime();
+            const minDate = new Date('November 10, 2020 00:00:00').getTime();
+            const maxDate = new Date('November 25, 2020 00:00:00').getTime();
+            const { container } = render(
+                <CalendarInput
+                    calendarPosition='static'
+                    calendarProps={{
+                        minDate,
+                        maxDate,
+                    }}
+                    defaultMonth={defaultMonth}
+                />,
+            );
+
+            const nonDisabledDays = container.querySelectorAll('button[data-date]:not(:disabled)');
+
+            expect(nonDisabledDays).toHaveLength(16);
+            expect(nonDisabledDays[0]).toHaveTextContent('10');
+            expect(nonDisabledDays[nonDisabledDays.length - 1]).toHaveTextContent('25');
+        });
+
         it('should set calendar value if value in [minDate, maxDate]', () => {
             const value = '01.12.2020';
             const minDate = new Date('November 10, 2020 00:00:00').getTime();
@@ -395,6 +417,52 @@ describe('CalendarInput', () => {
 
             expect(queryByText('Октябрь')).not.toBeInTheDocument();
             expect(queryByText('Ноябрь')).toBeInTheDocument();
+        });
+    });
+
+    describe('offdays', () => {
+        it('should set offDays', () => {
+            const defaultMonth = new Date('November 01, 2020 00:00:00').getTime();
+            const offDays = [
+                new Date('November 10, 2020 00:00:00').getTime(),
+                new Date('November 25, 2020 00:00:00').getTime(),
+            ];
+            const { container } = render(
+                <CalendarInput
+                    calendarPosition='static'
+                    offDays={offDays}
+                    defaultMonth={defaultMonth}
+                />,
+            );
+
+            const disabledDays = container.querySelectorAll('button[data-date]:disabled');
+
+            expect(disabledDays).toHaveLength(2);
+            expect(disabledDays[0]).toHaveTextContent('10');
+            expect(disabledDays[1]).toHaveTextContent('25');
+        });
+
+        it('should set offDays via calendarProps', () => {
+            const defaultMonth = new Date('November 01, 2020 00:00:00').getTime();
+            const offDays = [
+                new Date('November 10, 2020 00:00:00').getTime(),
+                new Date('November 25, 2020 00:00:00').getTime(),
+            ];
+            const { container } = render(
+                <CalendarInput
+                    calendarPosition='static'
+                    calendarProps={{
+                        offDays,
+                    }}
+                    defaultMonth={defaultMonth}
+                />,
+            );
+
+            const disabledDays = container.querySelectorAll('button[data-date]:disabled');
+
+            expect(disabledDays).toHaveLength(2);
+            expect(disabledDays[0]).toHaveTextContent('10');
+            expect(disabledDays[1]).toHaveTextContent('25');
         });
     });
 

--- a/packages/calendar-input/src/Component.tsx
+++ b/packages/calendar-input/src/Component.tsx
@@ -86,6 +86,11 @@ export type CalendarInputProps = Omit<
     maxDate?: number;
 
     /**
+     * Список выходных
+     */
+    offDays?: Array<Date | number>;
+
+    /**
      * Определяет, как рендерить календарь — в поповере или снизу инпута
      */
     calendarPosition?: 'static' | 'popover';
@@ -145,9 +150,10 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
             calendarPosition = 'popover',
             value,
             dataTestId,
-            minDate,
-            maxDate,
             calendarProps = {},
+            minDate = calendarProps.minDate,
+            maxDate = calendarProps.maxDate,
+            offDays = calendarProps.offDays || [],
             preventFlip,
             mobileMode = 'popover',
             wrapperRef = null,
@@ -175,7 +181,10 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
         const inputValue = uncontrolled ? stateValue : value;
         const calendarValue = inputValue ? parseDateString(inputValue).getTime() : undefined;
 
-        const isCalendarValueValid = dateInLimits(calendarValue, minDate, maxDate);
+        const isCalendarValueValid =
+            calendarValue &&
+            dateInLimits(calendarValue, minDate, maxDate) &&
+            !offDays.includes(calendarValue);
 
         const inputDisabled = disabled || readOnly;
 
@@ -311,6 +320,7 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
                         onChange={handleCalendarChange}
                         minDate={minDate}
                         maxDate={maxDate}
+                        offDays={offDays}
                     />
                 </div>
             ),
@@ -323,6 +333,7 @@ export const CalendarInput = forwardRef<HTMLInputElement, CalendarInputProps>(
                 isCalendarValueValid,
                 maxDate,
                 minDate,
+                offDays,
             ],
         );
 


### PR DESCRIPTION
Небольшой фикс, позволяющий задавать все свойства календаря через calendarProps.

Чтобы не делать мажорку, не стал убирать minDate, maxDate и offDays из пропсов CalendarInput. Теперь задать можно и напрямую и через calendarProps

### Проблема
Сейчас вот такой код не работает:

```tsx
<CalendarInput
    calendarProps={{
        minDate: 1622408400000,
        maxDate: 1623358800000,
        offDays: [1622408400000, 1622840400000, 1622926800000],
    }}
/>
```