### PR TITLE
feat(confirmation): set up signTitle prop as slot

### DIFF
--- a/packages/confirmation/src/Component.test.tsx
+++ b/packages/confirmation/src/Component.test.tsx
@@ -54,6 +54,29 @@ describe('Confirmation', () => {
             expect(container).toMatchSnapshot();
         });
 
+        it('should match snapshot with signTitle as string', () => {
+            const { container } = render(
+                <Confirmation {...baseProps} signTitle='Кастомный заголовок как текст' />,
+            );
+
+            expect(container).toMatchSnapshot();
+        });
+
+        it('should match snapshot with signTitle as react node', () => {
+            const { container } = render(
+                <Confirmation
+                    {...baseProps}
+                    signTitle={
+                        <div>
+                            <h1>Кастомный заголовок как react node</h1>
+                        </div>
+                    }
+                />,
+            );
+
+            expect(container).toMatchSnapshot();
+        });
+
         it('should math snapshot without smsCountdown', () => {
             const { container } = render(<Confirmation {...baseProps} hasSmsCountdown={false} />);
 

--- a/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/confirmation/src/__snapshots__/Component.test.tsx.snap
@@ -446,6 +446,276 @@ exports[`Confirmation Snapshot tests should match snapshot with nonFatal error 1
 </div>
 `;
 
+exports[`Confirmation Snapshot tests should match snapshot with signTitle as react node 1`] = `
+<div>
+  <div
+    class="component left"
+  >
+    <div
+      class="component left"
+    >
+      <div>
+        <h1>
+          Кастомный заголовок как react node
+        </h1>
+      </div>
+      <div
+        class="inputContainer"
+      >
+        <div
+          class="component codeInput"
+        >
+          <input
+            autocomplete="one-time-code"
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="1"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="2"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="3"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="4"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="5"
+          />
+        </div>
+        
+      </div>
+      <div
+        class="countdown countdown"
+      >
+        <div
+          class="component left"
+        >
+          
+          <div>
+            <div
+              class="info"
+            >
+              Запросить повторно можно через
+            </div>
+            <div
+              class="loaderWrap"
+            >
+              <svg
+                class="loader"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <defs>
+                  <mask
+                    id="cut"
+                  >
+                    <rect
+                      fill="white"
+                      height="100%"
+                      width="100%"
+                    />
+                    <circle
+                      cx="8"
+                      cy="8"
+                      fill="black"
+                      r="6"
+                    />
+                    <path
+                      d="M8 0 V8 L8 0 H0 L0 0 Z"
+                    />
+                  </mask>
+                </defs>
+                <circle
+                  class="circle"
+                  cx="8"
+                  cy="8"
+                  mask="url(#cut)"
+                  r="8"
+                />
+              </svg>
+              <div
+                class="timePassed"
+              >
+                01:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="smsComeLinkWrap"
+      >
+        <a
+          class="component secondary pseudo smsComeLink"
+        >
+          <span
+            class="text"
+          >
+            Не приходит сообщение?
+          </span>
+        </a>
+      </div>
+      <div />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Confirmation Snapshot tests should match snapshot with signTitle as string 1`] = `
+<div>
+  <div
+    class="component left"
+  >
+    <div
+      class="component left"
+    >
+      <span
+        class="header"
+      >
+        Кастомный заголовок как текст
+      </span>
+      <div
+        class="inputContainer"
+      >
+        <div
+          class="component codeInput"
+        >
+          <input
+            autocomplete="one-time-code"
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="1"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="2"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="3"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="4"
+          />
+          <input
+            autocomplete=""
+            class="input left"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            value="5"
+          />
+        </div>
+        
+      </div>
+      <div
+        class="countdown countdown"
+      >
+        <div
+          class="component left"
+        >
+          
+          <div>
+            <div
+              class="info"
+            >
+              Запросить повторно можно через
+            </div>
+            <div
+              class="loaderWrap"
+            >
+              <svg
+                class="loader"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <defs>
+                  <mask
+                    id="cut"
+                  >
+                    <rect
+                      fill="white"
+                      height="100%"
+                      width="100%"
+                    />
+                    <circle
+                      cx="8"
+                      cy="8"
+                      fill="black"
+                      r="6"
+                    />
+                    <path
+                      d="M8 0 V8 L8 0 H0 L0 0 Z"
+                    />
+                  </mask>
+                </defs>
+                <circle
+                  class="circle"
+                  cx="8"
+                  cy="8"
+                  mask="url(#cut)"
+                  r="8"
+                />
+              </svg>
+              <div
+                class="timePassed"
+              >
+                01:00
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="smsComeLinkWrap"
+      >
+        <a
+          class="component secondary pseudo smsComeLink"
+        >
+          <span
+            class="text"
+          >
+            Не приходит сообщение?
+          </span>
+        </a>
+      </div>
+      <div />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Confirmation Snapshot tests should match snapshot with unmasked phone 1`] = `
 <div>
   <div

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -80,7 +80,7 @@ export type ConfirmationProps = {
     /**
      * Заголовок экрана подписания
      */
-    signTitle?: string;
+    signTitle?: string | React.ReactNode;
 
     /**
      * Заголовок экрана блокирующей ошибки

--- a/packages/confirmation/src/components/sign-confirmation/component.tsx
+++ b/packages/confirmation/src/components/sign-confirmation/component.tsx
@@ -22,7 +22,7 @@ export type SignConfirmationProps = {
     code: string;
     errorText: string;
     error: boolean;
-    title: string;
+    title: string | React.ReactNode;
     codeCheckingText: string;
     codeSendingText: string;
     hasSmsCountdown: boolean;
@@ -98,7 +98,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
 
     return (
         <div className={cn(styles.component, styles[alignContent])}>
-            <span className={styles.header}>{title}</span>
+            {typeof title === 'string' ? <span className={styles.header}>{title}</span> : title}
 
             <div className={styles.inputContainer}>
                 <CodeInput


### PR DESCRIPTION
Добавил возможность использовать signTitle prop как строку - так и jsx
- чтобы иметь возможность вставлять кастомный компонент вместо строки. 
