### PR TITLE
fix(dropzone): add pointer-events none to overlay

### DIFF
--- a/packages/dropzone/src/index.module.css
+++ b/packages/dropzone/src/index.module.css
@@ -16,6 +16,7 @@
         bottom: 0;
         left: 0;
         right: 0;
+        pointer-events: none;
 
         border-radius: var(--border-radius-s);
 


### PR DESCRIPTION
Пофиксил баг
>  всё что внутри дропзоны перекрывается невидимым оверлеем и становится некликабельным