### PR TITLE
fix(select): calc height in effect

### DIFF
--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -1,12 +1,4 @@
-import {
-    useRef,
-    useEffect,
-    ReactNode,
-    isValidElement,
-    cloneElement,
-    useLayoutEffect,
-    RefObject,
-} from 'react';
+import { useRef, useEffect, ReactNode, isValidElement, cloneElement, RefObject } from 'react';
 import { OptionShape, GroupShape, BaseSelectProps } from './typings';
 
 export const isGroup = (item: OptionShape | GroupShape): item is GroupShape =>
@@ -106,7 +98,7 @@ export function useVisibleOptions({
     open,
     invalidate,
 }: useVisibleOptionsArgs) {
-    useLayoutEffect(() => {
+    useEffect(() => {
         const list = listRef.current;
         const styleTarget = styleTargetRef.current;
 


### PR DESCRIPTION
[Чинит такой кейс](https://alfa-laboratory.github.io/core-components/master/?path=/docs/%D0%B3%D0%B0%D0%B9%D0%B4%D0%BB%D0%B0%D0%B9%D0%BD%D1%8B-%D0%BF%D0%B5%D1%81%D0%BE%D1%87%D0%BD%D0%B8%D1%86%D0%B0--page/code=const%20options%20%3D%20%5B%0A%20%20%20%20%7B%20key%3A%20%271%27%2C%20content%3A%20%27Neptunium%20Neptunium%20Neptunium%20Neptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20NeptuniumNeptunium%20Neptunium%20Neptunium%27%7D%2C%0A%5D%3B%0A%0Arender(%0A%3Cdiv%20style%3D%7B%7B%20width%3A%20320%20%7D%7D%3E%0A%20%20%3CInputAutocomplete%20options%3D%7Boptions%7D%20label%3D%22select%22%20block%3D%7Btrue%7D%20optionsListWidth%3D%22field%22%20%2F%3E%0A%3C%2Fdiv%3E%0A))

Сделал так, чтобы высота пунктов рассчитывалась после расчета ширины, а не наоборот