### PR TITLE
fix(calendar-with-skeleton): ref & six weeks height issues

### DIFF
--- a/packages/calendar-with-skeleton/src/Component.tsx
+++ b/packages/calendar-with-skeleton/src/Component.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-
+import cn from 'classnames';
 import { CSSTransition } from 'react-transition-group';
 
 import { Skeleton } from '@alfalab/core-components-skeleton';
@@ -24,7 +24,11 @@ export const CalendarWithSkeleton = forwardRef<HTMLDivElement, CalendarWithSkele
         const skeletonProps = { visible: true, animate };
 
         return (
-            <div className={styles.component}>
+            <div
+                className={cn(styles.component, {
+                    [styles.calendarVisible]: calendarVisible,
+                })}
+            >
                 {calendarVisible && <Calendar ref={ref} {...restProps} />}
 
                 <CSSTransition
@@ -33,7 +37,7 @@ export const CalendarWithSkeleton = forwardRef<HTMLDivElement, CalendarWithSkele
                     unmountOnExit={true}
                     classNames={styles}
                 >
-                    <div className={styles.skeleton} ref={ref}>
+                    <div className={styles.skeleton} ref={calendarVisible ? undefined : ref}>
                         <Skeleton {...skeletonProps} className={styles.header} />
 
                         <Skeleton {...skeletonProps} className={styles.weekDays} />

--- a/packages/calendar-with-skeleton/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/calendar-with-skeleton/src/__snapshots__/Component.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Calendar Render tests should render calendar when calendarVisible=\`true\` 1`] = `
 <div>
   <div
-    class="component"
+    class="component calendarVisible"
   >
     <div
       class="component sixWeeks"

--- a/packages/calendar-with-skeleton/src/index.module.css
+++ b/packages/calendar-with-skeleton/src/index.module.css
@@ -6,6 +6,10 @@
     position: relative;
 }
 
+.calendarVisible {
+    height: auto;
+}
+
 .skeleton {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
[Демка с багами](https://alfa-laboratory.github.io/core-components/master/?path=/docs/%D0%B3%D0%B0%D0%B9%D0%B4%D0%BB%D0%B0%D0%B9%D0%BD%D1%8B-%D0%BF%D0%B5%D1%81%D0%BE%D1%87%D0%BD%D0%B8%D1%86%D0%B0--page/code=const%20CustomCalendar%20%3D%20React.forwardRef((props%2C%20ref)%20%3D%3E%20%7B%0A%20%20const%20%5BcalendarVisible%2C%20setCalendarVisible%5D%20%3D%20React.useState(false)%3B%0A%0A%20%20React.useEffect(()%20%3D%3E%20%7B%0A%20%20%20%20setTimeout(()%20%3D%3E%20setCalendarVisible(true)%2C%201500)%3B%0A%20%20%7D%2C%5B%5D)%3B%0A%0A%20%20return%20%3CCalendarWithSkeleton%20calendarVisible%3D%7BcalendarVisible%7D%20ref%3D%7Bref%7D%20%7B...props%7D%20%2F%3E%0A%7D)%3B%0A%0Afunction%20Example()%20%7B%0A%20%20%20%20const%20%5Bvisible%2C%20setVisible%5D%20%3D%20React.useState(false)%3B%0A%20%20%20%20return%20%3CCalendarInput%20label%3D%27%D0%94%D0%B0%D1%82%D0%B0%20%D1%80%D0%B5%D0%B3%D0%B8%D1%81%D1%82%D1%80%D0%B0%D1%86%D0%B8%D0%B8%27%20value%3D%2201.08.2021%22%20Calendar%3D%7BCustomCalendar%7D%20%2F%3E%0A%7D%0Arender(%3CExample%20%2F%3E)%3B)

— Вывалились даты, если в месяце 6 недель
— Не закрывается календарь после загрузки