### PR TITLE
feat(confirmation): add property for change retry button text

### DIFF
--- a/packages/confirmation/src/Component.test.tsx
+++ b/packages/confirmation/src/Component.test.tsx
@@ -203,8 +203,8 @@ describe('Confirmation', () => {
     });
 
     describe('Sms retry tests', () => {
-        const buttonRetryInHintText = Confirmation.defaultProps?.buttonRetryText;
-        const buttonRetryText = 'Запросить новый код';
+        const buttonReturnInHintText = Confirmation.defaultProps?.buttonReturnText as string;
+        const buttonRetryText = Confirmation.defaultProps?.buttonRetryText as string;
         const hintLinkText = 'Не приходит сообщение?';
 
         it('should display retry button', async () => {
@@ -214,14 +214,30 @@ describe('Confirmation', () => {
             expect(buttonRetry).toBeInTheDocument();
         });
 
-        it('should set custom buttonRetryText in hint', async () => {
-            const customButtonRetryTextInHint = 'Send code again';
+        it('should set custom buttonRetryText', async () => {
+            const customButtonRetryText = 'Запросить код повторно';
+
+            const { findByText } = render(
+                <Confirmation
+                    {...baseProps}
+                    buttonRetryText={customButtonRetryText}
+                    countdownDuration={0}
+                />,
+            );
+
+            const buttonRetry = await findByText(customButtonRetryText);
+
+            expect(buttonRetry).toBeInTheDocument();
+        });
+
+        it('should set custom buttonReturnText in hint', async () => {
+            const customButtonReturnTextInHint = 'Send code again';
 
             const { findByText } = render(
                 <Confirmation
                     {...baseProps}
                     countdownDuration={0}
-                    buttonRetryText={customButtonRetryTextInHint}
+                    buttonReturnText={customButtonReturnTextInHint}
                 />,
             );
 
@@ -231,7 +247,7 @@ describe('Confirmation', () => {
             const smsHintButton = await findByText(hintLinkText);
             smsHintButton.click();
 
-            const buttonWithCustomText = await findByText(customButtonRetryTextInHint);
+            const buttonWithCustomText = await findByText(customButtonReturnTextInHint);
 
             expect(buttonWithCustomText).toBeInTheDocument();
         });
@@ -270,7 +286,7 @@ describe('Confirmation', () => {
             const smsHintButton = await findByText(hintLinkText);
             smsHintButton.click();
 
-            const buttonRetryInHint = await findByText(buttonRetryInHintText as string);
+            const buttonRetryInHint = await findByText(buttonReturnInHintText);
             buttonRetryInHint.click();
 
             expect(onSmsRetryClick).toBeCalled();

--- a/packages/confirmation/src/Component.test.tsx
+++ b/packages/confirmation/src/Component.test.tsx
@@ -220,8 +220,8 @@ describe('Confirmation', () => {
             const { findByText } = render(
                 <Confirmation
                     {...baseProps}
-                    buttonRetryText={customButtonRetryText}
                     countdownDuration={0}
+                    buttonRetryText={customButtonRetryText}
                 />,
             );
 

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -108,6 +108,11 @@ export type ConfirmationProps = {
     buttonErrorText?: string;
 
     /**
+     * Текст кнопки "Вернуться назад" на экране помощи
+     */
+    buttonReturnText?: string;
+
+    /**
      * Текст кнопки "Запросить код"
      */
     buttonRetryText?: string;
@@ -177,7 +182,8 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
             codeCheckingText = 'Проверка кода',
             codeSendingText = 'Отправляем код',
             buttonErrorText = 'Понятно',
-            buttonRetryText = 'Вернуться назад',
+            buttonReturnText = 'Вернуться назад',
+            buttonRetryText = 'Запросить новый код',
             alignContent = 'left',
             noAttemptsLeftMessage,
             onInputFinished,
@@ -262,6 +268,7 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                         errorText={nonFatalError || ''}
                         error={error}
                         title={signTitle}
+                        buttonRetryText={buttonRetryText}
                         inputRef={inputRef}
                         codeCheckingText={codeCheckingText}
                         codeSendingText={codeSendingText}
@@ -326,7 +333,7 @@ export const Confirmation = forwardRef<HTMLDivElement, ConfirmationProps>(
                             view='secondary'
                             onClick={handleSmsRetryFromHintClick}
                         >
-                            {buttonRetryText}
+                            {buttonReturnText}
                         </Button>
                     </div>
                 )}
@@ -350,6 +357,7 @@ Confirmation.defaultProps = {
     codeCheckingText: 'Проверка кода',
     codeSendingText: 'Отправляем код',
     buttonErrorText: 'Понятно',
-    buttonRetryText: 'Вернуться назад',
+    buttonReturnText: 'Вернуться назад',
+    buttonRetryText: 'Запросить новый код',
     alignContent: 'left',
 };

--- a/packages/confirmation/src/component.tsx
+++ b/packages/confirmation/src/component.tsx
@@ -113,7 +113,7 @@ export type ConfirmationProps = {
     buttonReturnText?: string;
 
     /**
-     * Текст кнопки "Запросить код"
+     * Текст кнопки "Запросить новый код"
      */
     buttonRetryText?: string;
 

--- a/packages/confirmation/src/components/countdown/component.tsx
+++ b/packages/confirmation/src/components/countdown/component.tsx
@@ -49,6 +49,7 @@ export type CountdownProps = {
     hasPhoneMask: boolean;
     phone?: string;
     alignContent: string;
+    buttonRetryText: string;
     noAttemptsLeftMessage?: string;
     hasError: boolean;
     onCountdownFinished?: () => void;
@@ -59,6 +60,7 @@ export const Countdown: FC<CountdownProps> = ({
     duration = 5000,
     phone = '',
     hasPhoneMask = true,
+    buttonRetryText,
     alignContent,
     noAttemptsLeftMessage,
     hasError,
@@ -157,7 +159,7 @@ export const Countdown: FC<CountdownProps> = ({
                     onClick={handleRepeatSmsButtonClick}
                     className={styles.getCodeButton}
                 >
-                    Запросить новый код
+                    {buttonRetryText}
                 </Button>
             ) : (
                 <div>

--- a/packages/confirmation/src/components/sign-confirmation/component.tsx
+++ b/packages/confirmation/src/components/sign-confirmation/component.tsx
@@ -29,6 +29,7 @@ export type SignConfirmationProps = {
     inputRef: MutableRefObject<HTMLInputElement | null>;
     alignContent: ContentAlign;
     noAttemptsLeftMessage?: string;
+    buttonRetryText: string;
     onInputFinished: ({ code }: { code: string }) => void;
     onInputChange: ({ code }: { code: string }) => void;
     onSmsRetryClick: (event: React.MouseEvent) => void;
@@ -55,6 +56,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
     codeSendingText,
     alignContent,
     noAttemptsLeftMessage,
+    buttonRetryText,
     onInputFinished,
     onInputChange,
     onSmsRetryClick,
@@ -135,6 +137,7 @@ export const SignConfirmation: FC<SignConfirmationProps> = ({
                         alignContent={alignContent}
                         noAttemptsLeftMessage={noAttemptsLeftMessage}
                         hasError={Boolean(displayedError)}
+                        buttonRetryText={buttonRetryText}
                         onRepeatSms={onSmsRetryClick}
                         onCountdownFinished={onCountdownFinished}
                     />


### PR DESCRIPTION
Сейчас `buttonRetryText` меняет текст на кнопке, которая находится на экране помощи (необходимо нажать на псевдо-ссылку "Не приходит сообщение?"), что, на мой взгляд, не совсем очевидно, т.к. есть еще кнопка которая запрашивает новый код после окончания таймера.

Добавляю `buttonReturnText` для кнопки на экране помощи и переназначаю `buttonRetryText` на кнопку, которая покажется после окончания таймера.