### PR TITLE
fix(input): autofocus

### DIFF
--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -192,6 +192,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             defaultValue,
             wrapperRef,
             readOnly,
+            autoFocus,
             ...restProps
         },
         ref,
@@ -200,9 +201,13 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         const inputRef = useRef<HTMLInputElement>(null);
 
-        const [focusVisible] = useFocus(inputRef, 'keyboard');
+        let [focusVisible] = useFocus(inputRef, 'keyboard');
 
-        const [focused, setFocused] = useState(false);
+        if (inputRef.current === null) {
+            focusVisible = Boolean(autoFocus);
+        }
+
+        const [focused, setFocused] = useState(autoFocus);
         const [stateValue, setStateValue] = useState(defaultValue || '');
 
         const filled = Boolean(uncontrolled ? stateValue : value);

--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -192,7 +192,6 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             defaultValue,
             wrapperRef,
             readOnly,
-            autoFocus,
             ...restProps
         },
         ref,
@@ -201,13 +200,9 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
         const inputRef = useRef<HTMLInputElement>(null);
 
-        let [focusVisible] = useFocus(inputRef, 'keyboard');
+        const [focusVisible] = useFocus(inputRef, 'keyboard');
 
-        if (inputRef.current === null) {
-            focusVisible = Boolean(autoFocus);
-        }
-
-        const [focused, setFocused] = useState(autoFocus);
+        const [focused, setFocused] = useState(restProps.autoFocus);
         const [stateValue, setStateValue] = useState(defaultValue || '');
 
         const filled = Boolean(uncontrolled ? stateValue : value);


### PR DESCRIPTION
В этом пр исправляется проблема лейбла наезжающего на картеку инпута с автофокусом.
Похоже вся проблема в том, что состояние фокуса хранится не только в доме, но и в `useFocus` и
в `const [focused, setFocused] = useState()`

Отсюда следует что оно может расходится. Что и происходит при монтировании <Input autoFocus />, стейт компонента в расфокусе а дом-нода в фокусе