### PR TITLE
feat(amount-input): add integers only mode

### DIFF
--- a/packages/amount-input/src/Component.tsx
+++ b/packages/amount-input/src/Component.tsx
@@ -31,6 +31,11 @@ export type AmountInputProps = Omit<InputProps, 'value' | 'onChange' | 'type'> &
     minority?: number;
 
     /**
+     * Позволяет вводить только целые значения
+     */
+    integersOnly?: boolean;
+
+    /**
      * Жир
      */
     bold?: boolean;
@@ -69,6 +74,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
             integerLength = 9,
             minority = 100,
             currency = 'RUR',
+            integersOnly = false,
             placeholder = `0\u2009${getCurrencySymbol(currency) || ''}`,
             bold = true,
             className,
@@ -113,7 +119,12 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
 
         const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
             const input = e.target;
-            const enteredValue = input.value.replace(/\s/g, '').replace('.', ',');
+            let enteredValue = input.value.replace(/\s/g, '').replace('.', ',');
+
+            if (integersOnly) {
+                [enteredValue] = enteredValue.split(',');
+            }
+
             const isCorrectEnteredValue = RegExp(
                 `(^[0-9]{1,${integerLength}}(,([0-9]+)?)?$|^\\s*$)`,
             ).test(enteredValue);

--- a/packages/amount-input/src/docs/Component.stories.mdx
+++ b/packages/amount-input/src/docs/Component.stories.mdx
@@ -24,6 +24,7 @@ import styles from '!!raw-loader!../index.module.css';
         currency={text('currency', 'RUR')}
         integerLength={number('integerLength', 9)}
         minority={number('minority', 100)}
+        integersOnly={boolean('integersOnly', false)}
         bold={boolean('bold', true)}
         block={boolean('block', false)}
         size={select('size', ['s', 'm', 'l', 'xl'], 's')}


### PR DESCRIPTION
Добавляет возможность ограничить ввод только целыми числами через `integersOnly`. 
Применяется только к вводу