### PR TITLE
Feat/select lazy load

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
         "development": [
             "last 1 chrome version",
             "last 1 firefox version",
-            "last 1 safari version"
+            "last 1 safari version",
+            "ie >= 11"
         ]
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "date-fns": "^2.16.1",
         "downshift": "5.4.7",
         "element-closest": "^3.0.2",
+        "intersection-observer": "^0.12.0",
         "libphonenumber-js": "^1.8.4",
         "lodash.debounce": "^4.0.8",
         "react-focus-lock": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
         "development": [
             "last 1 chrome version",
             "last 1 firefox version",
-            "last 1 safari version",
-            "ie >= 11"
+            "last 1 safari version"
         ]
     },
     "dependencies": {

--- a/packages/select/src/Component.test.tsx
+++ b/packages/select/src/Component.test.tsx
@@ -416,7 +416,7 @@ describe('Select', () => {
         });
 
         it('should transfer props to OptionsList', () => {
-            const spy = jest.spyOn(optionsListModule, 'OptionsList');
+            const spy = jest.spyOn(optionsListModule.OptionsList, 'render' as never);
 
             const optionsListProps: Partial<OptionsListProps> = {
                 emptyPlaceholder: 'list-placeholder',

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -205,11 +205,11 @@ export const BaseSelect = forwardRef(
         };
 
         const handleFieldBlur = (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => {
-            if (
-                !listRef.current?.contains(
-                    (event.relatedTarget || document.activeElement) as HTMLElement,
-                )
-            ) {
+            const isNextFocusInsideList = listRef.current?.contains(
+                (event.relatedTarget || document.activeElement) as HTMLElement,
+            );
+
+            if (!isNextFocusInsideList) {
                 if (onBlur) onBlur(event);
 
                 inputProps.onBlur(event);

--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -205,20 +205,30 @@ export const BaseSelect = forwardRef(
         };
 
         const handleFieldBlur = (event: FocusEvent<HTMLDivElement | HTMLInputElement>) => {
-            if (onBlur) onBlur(event);
+            if (
+                !listRef.current?.contains(
+                    (event.relatedTarget || document.activeElement) as HTMLElement,
+                )
+            ) {
+                if (onBlur) onBlur(event);
 
-            inputProps.onBlur(event);
+                inputProps.onBlur(event);
+            }
         };
 
         const handleFieldKeyDown = (event: KeyboardEvent<HTMLDivElement | HTMLInputElement>) => {
             inputProps.onKeyDown(event);
-
             if (autocomplete && !open && event.key.length === 1) {
                 // Для автокомплита - открываем меню при начале ввода
                 openMenu();
             }
 
-            if ([' ', 'Enter'].includes(event.key) && !autocomplete && !nativeSelect) {
+            if (
+                [' ', 'Enter'].includes(event.key) &&
+                !autocomplete &&
+                !nativeSelect &&
+                (event.target as HTMLElement).tagName !== 'INPUT'
+            ) {
                 // Открываем\закрываем меню по нажатию enter или пробела
                 event.preventDefault();
                 if (!open || highlightedIndex === -1) toggleMenu();

--- a/packages/select/src/docs/description.mdx
+++ b/packages/select/src/docs/description.mdx
@@ -573,10 +573,18 @@ const mockOptions = (offset, limit, queryString) => ({
 // Для корректной работы Input должен принимать в себя ...inputProps,
 // OptionsList должен принимать ref и остальные ...props
 const CustomOptionsList = React.forwardRef(({inputProps, ...props}, ref) => {
+    const inputRef = React.useRef();
+
+    React.useLayoutEffect(() => {
+        // Нужно для того, чтобы инпут фокусировался в поле уже после того, как OptionsList
+        // спозиционируется относительно инпута, и тогда не произойдет скачка экрана
+        setTimeout(() => inputRef.current.focus(), 0);
+    }, []);
+
     return (
         <div>
             <div style={{padding: '5px'}}>
-                <Input label='Поиск' {...inputProps} block={true} />
+                <Input label='Поиск' {...inputProps} block={true} ref={inputRef}/>
             </div>
             <OptionsList {...props} ref={ref} />
         </div>

--- a/packages/select/src/docs/description.mdx
+++ b/packages/select/src/docs/description.mdx
@@ -511,4 +511,102 @@ render(() => {
         </div>
     );
 });
+
+```
+### Ленивая загрузка опций
+
+#### Простая ленивая загрузка
+```tsx live
+const LIMIT = 10;
+
+const sleep = () => new Promise(r => setTimeout(r, 2000));
+const mockOptions = (offset) => ({
+    options: Array(LIMIT).fill(0).map((_, i) => ({
+        key: `${offset}${i}`,
+        content: `Option number ${offset}${i}`,
+    })),
+    hasMore: offset < 4
+});
+
+render(() => {
+    const fetchOptions = (offset) => {
+        return sleep().then(() => {
+            return mockOptions(offset);
+        });
+    };
+    const {
+        optionsProps,
+    } = useLazyLoading({
+        limit: LIMIT,
+        optionsFetcher: fetchOptions,
+    });
+
+
+    return (
+        <div style={{ width: 320 }}>
+            <Select
+                label='Простая ленивая загрузка'
+                preventFlip={false}
+                size='l'
+                {...optionsProps}
+            />
+        </div>
+    );
+});
+```
+
+#### Ленивая загрузка с поддержкой поиска по строке
+```tsx live
+const LIMIT = 15;
+
+const sleep = () => new Promise(r => setTimeout(r, 2000));
+const mockOptions = (offset, limit, queryString) => ({
+    options: Array(LIMIT).fill(0).map((_, i) => ({
+        key: `${offset}${i}`,
+        content: queryString ?
+            `Опция ${offset * limit + i}, удовлетворяющая поисковой строке "${queryString}"` :
+            `Option number ${offset * limit + i}`
+    })),
+    hasMore: offset < 4
+});
+
+// Для корректной работы Input должен принимать в себя ...inputProps,
+// OptionsList должен принимать ref и остальные ...props
+const CustomOptionsList = React.forwardRef(({inputProps, ...props}, ref) => {
+    return (
+        <div>
+            <div style={{padding: '5px'}}>
+                <Input label='Поиск' {...inputProps} block={true} />
+            </div>
+            <OptionsList {...props} ref={ref} />
+        </div>
+    )
+});
+
+render(() => {
+    const fetchOptions = (offset, limit, queryString) => {
+        return sleep().then(() => {
+            return mockOptions(offset, limit, queryString);
+        });
+    };
+    const {
+        optionsProps,
+    } = useLazyLoading({
+        limit: LIMIT,
+        optionsFetcher: fetchOptions,
+    });
+
+
+    return (
+        <div style={{ width: 320 }}>
+            <Select
+                label='Ленивая загрузка с поддержкой поиска по строке'
+                preventFlip={false}
+                size='l'
+                {...optionsProps}
+                OptionsList={CustomOptionsList}
+            />
+        </div>
+    );
+});
 ```

--- a/packages/select/src/presets/index.ts
+++ b/packages/select/src/presets/index.ts
@@ -1,1 +1,2 @@
 export * from './useSelectWithLoading/hook';
+export * from './useLazyLoading/hook';

--- a/packages/select/src/presets/useLazyLoading/hook.tsx
+++ b/packages/select/src/presets/useLazyLoading/hook.tsx
@@ -1,0 +1,255 @@
+import React, { Reducer, useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import { Skeleton } from '@alfalab/core-components-skeleton';
+import { InputProps } from '@alfalab/core-components-input';
+import { Option } from '../../components/option';
+import { OptionShape } from '../../typings';
+import styles from './index.module.css';
+
+const DEBOUNCE_TIMEOUT = 300;
+
+type OptionsFetcherResponse = {
+    options: OptionShape[];
+    hasMore: boolean;
+};
+
+type useLazyLoadingProps = {
+    /** Количество элементов на "странице" */
+    limit?: number;
+
+    /** Начальный номер "страницы" */
+    initialOffset?: number;
+
+    /** Скелетон загружаемых элементов */
+    skeleton?: React.ReactNode;
+
+    /**
+     * Функция-загрузчик опций.
+     * @param offset - текущая страница
+     * @param limit - количество элементов на странице
+     * @param queryString - строчные данные, пробрасываемые для поиска из кастомного инпута, расположенного в заголовке OptionsList
+     * @returns Promise<{
+     *  options - список опций следующей "страницы". Они аппендятся к предыдущим
+     *  hasMore - указывает, есть ли еще незагруженные элементы (в случае false перестает загружать "следующую страницу")
+     * }>
+     */
+    optionsFetcher<T>(
+        offset: number,
+        limit: number,
+        queryString?: string,
+    ): Promise<OptionsFetcherResponse>;
+};
+
+const actions = {
+    fetchOptionsStart() {
+        return { type: 'FETCH_OPTIONS_START' } as const;
+    },
+    fetchOptionsSuccess(payload: { options: OptionShape[]; hasMore: boolean }) {
+        return { type: 'FETCH_OPTIONS_SUCCESS', payload } as const;
+    },
+    setIsOpened(opened: boolean) {
+        return { type: 'SET_IS_OPENED', payload: opened } as const;
+    },
+    setQueryString(qs: string) {
+        return { type: 'SET_QUERY_STRING', payload: qs } as const;
+    },
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Actions = typeof actions extends { [key: string]: (...args: any) => infer U } ? U : never;
+
+export function useLazyLoading({
+    limit = 10,
+    initialOffset = 0,
+    optionsFetcher,
+    skeleton = <Skeleton className={styles.skeleton} visible={true} />,
+}: useLazyLoadingProps) {
+    const initialOptions: OptionShape[] = [];
+    const initialLoading = false;
+
+    const lazyLoadingInitialState = {
+        opened: false,
+        offset: initialOffset,
+        options: initialOptions,
+        loading: initialLoading,
+        allOptionsLoaded: false,
+        queryString: '',
+    };
+
+    const lazyLoadingReducer: Reducer<typeof lazyLoadingInitialState, Actions> = (
+        state,
+        action,
+    ) => {
+        switch (action.type) {
+            case 'FETCH_OPTIONS_START': {
+                return {
+                    ...state,
+                    loading: true,
+                };
+            }
+            case 'FETCH_OPTIONS_SUCCESS': {
+                return {
+                    ...state,
+                    options: [...state.options, ...action.payload.options],
+                    offset: state.offset + 1,
+                    allOptionsLoaded: !action.payload.hasMore,
+                    loading: false,
+                };
+            }
+            case 'SET_IS_OPENED': {
+                return {
+                    ...state,
+                    opened: action.payload,
+                };
+            }
+            case 'SET_QUERY_STRING': {
+                return {
+                    // Изменение queryString подразумевает сброс текущих опций.
+                    ...lazyLoadingInitialState,
+                    opened: state.opened,
+                    loading: true,
+                    queryString: action.payload,
+                };
+            }
+        }
+
+        return state;
+    };
+
+    const [
+        { opened, offset, options, loading, allOptionsLoaded, queryString },
+        dispatch,
+    ] = useReducer(lazyLoadingReducer, lazyLoadingInitialState);
+
+    const renderOption = useCallback(
+        props => (
+            <Option {...props} Checkmark={null} highlighted={loading ? false : props.highlighted} />
+        ),
+        [loading],
+    );
+
+    const skeletonOptions: OptionShape[] = useMemo(() => {
+        return Array(loading ? limit : 0)
+            .fill(0)
+            .map((_, key) => ({
+                key: `loading-${key}`,
+                disabled: true,
+                content: skeleton,
+            }));
+    }, [loading, limit, skeleton]);
+
+    const abortFetchingOptionsRef = useRef<() => void>();
+
+    const fetchNextOffsetOptions = useCallback(() => {
+        dispatch(actions.fetchOptionsStart());
+
+        new Promise<OptionsFetcherResponse>((resolve, reject) => {
+            abortFetchingOptionsRef.current = reject;
+            optionsFetcher(offset, limit, queryString).then(res => {
+                resolve(res);
+                abortFetchingOptionsRef.current = undefined;
+            });
+        })
+            .then(res => {
+                dispatch(actions.fetchOptionsSuccess(res));
+            })
+            .catch(
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                () => {},
+            );
+    }, [optionsFetcher, offset, limit, queryString]);
+
+    const listRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (opened && !loading && !allOptionsLoaded) {
+            const observer = new IntersectionObserver(
+                ([entry]) => {
+                    if (entry.isIntersecting) {
+                        observer.disconnect();
+                        fetchNextOffsetOptions();
+                    }
+                },
+                {
+                    root: listRef.current,
+                },
+            );
+
+            /*
+             * Обсервим пересечение последней опции с контейнером.
+             * Таким образом, загрузка следующей "страницы" начнется когда юзер доскроллит список
+             * до верхнего края последней опции, что обеспечивает плавность
+             */
+            const lastOption = listRef.current?.lastElementChild;
+            if (lastOption) {
+                observer.observe(lastOption);
+            }
+        }
+    }, [offset, fetchNextOffsetOptions, opened, allOptionsLoaded, initialOffset, loading]);
+
+    const onOpen = useCallback(
+        (payload: { open?: boolean }) => {
+            if (payload.open) {
+                if (options.length === initialOptions.length) {
+                    fetchNextOffsetOptions();
+                }
+            }
+
+            dispatch(actions.setIsOpened(payload.open ?? false));
+        },
+        [initialOptions.length, fetchNextOffsetOptions, options.length],
+    );
+
+    const fetchNextOptionsRef = useRef<() => void>();
+    const fetchNextOptionsTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        fetchNextOptionsRef.current = fetchNextOffsetOptions;
+    }, [fetchNextOffsetOptions]);
+
+    const onQueryStringChange = useCallback<Exclude<InputProps['onChange'], undefined>>(
+        (_, payload) => {
+            dispatch(actions.setQueryString(payload.value));
+            /* eslint-disable no-unused-expressions */
+
+            /*
+             * Если во время загрузки опций юзер ввел новый текст в инпут,
+             * нужно прервать текущую загрузку, чтобы неактуальные опции не попали в выдачу
+             */
+            abortFetchingOptionsRef.current?.();
+
+            listRef.current?.scrollTo({ top: 0 });
+
+            /* Дебаунсим ввод текста, чтобы не отправлять запрос к новым опциям на каждый чих */
+            if (fetchNextOptionsTimerRef.current) {
+                clearTimeout(fetchNextOptionsTimerRef.current);
+            }
+            fetchNextOptionsTimerRef.current = setTimeout(() => {
+                /*
+                 * После дебаунса необходимо вызвать функцию-загрузчик,
+                 * содержащую актуальные на данный момент данные оффсета и queryString.
+                 * Поэтому мы не можем обратиться напрямую к функции fetchNextOptions,
+                 * так как она будет замкнута на старые значения, актуальные на момент вызова хэндлера,
+                 * так что берем ее из обновляемого рефа
+                 */
+                fetchNextOptionsRef.current?.();
+            }, DEBOUNCE_TIMEOUT);
+            /* eslint-enable */
+        },
+        [],
+    );
+
+    return {
+        optionsProps: {
+            Option: renderOption,
+            options: [...options, ...skeletonOptions],
+            optionsListProps: {
+                ref: listRef,
+                inputProps: {
+                    onChange: onQueryStringChange,
+                    value: queryString,
+                },
+            },
+            onOpen,
+        },
+    };
+}

--- a/packages/select/src/presets/useLazyLoading/hook.tsx
+++ b/packages/select/src/presets/useLazyLoading/hook.tsx
@@ -1,3 +1,5 @@
+import 'intersection-observer';
+
 import React, { Reducer, useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { Skeleton } from '@alfalab/core-components-skeleton';
 import { InputProps } from '@alfalab/core-components-input';

--- a/packages/select/src/presets/useLazyLoading/index.module.css
+++ b/packages/select/src/presets/useLazyLoading/index.module.css
@@ -1,0 +1,7 @@
+.skeleton {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    height: 16px;
+    width: 50%;
+}

--- a/packages/select/src/presets/useLazyLoading/use-lazy-loading.test.tsx
+++ b/packages/select/src/presets/useLazyLoading/use-lazy-loading.test.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import { fireEvent, render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+
+import { OptionsList, Select, useLazyLoading } from '../../index';
+import { Skeleton } from '../../../../skeleton';
+import { Input } from '../../../../input';
+import { OptionsListProps } from '../../../../picker-button/dist/Component-2e5019e8';
+
+const LIMIT = 10;
+const TIME_TO_FETCH = 250;
+const sleep = () => new Promise(r => setTimeout(r, TIME_TO_FETCH));
+const mockOptions = (offset: number) => ({
+    options: Array(LIMIT)
+        .fill(0)
+        .map((_, i) => ({
+            key: `${offset}${i}`,
+            content: `Option number ${offset}${i}`,
+        })),
+    hasMore: offset < 2,
+});
+
+describe('Select useLazyLoading hook', () => {
+    const observe = jest.fn();
+
+    /*
+     * Так как у нас нет возможности проверить настоящую работу IntersectionObserver,
+     * Переопределим его поведение, доверясь браузеру, что он работает :)
+     * Вместо этого, все, что мы можем сделать - это проверить, с теми ли он параметрами он
+     * создался (следим за пересечением последней опции с контейнером)
+     * А так же эмулируем пересечение через 100ms.
+     * Таким образом мы сможем проверить правильность работы добавления опций в список.
+     */
+    type Entries = [{ isIntersecting: true }];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).IntersectionObserver = class {
+        private readonly callback: (e: Entries) => void;
+
+        private readonly options: { root: HTMLElement };
+
+        constructor(
+            callback: (e: Entries) => void,
+            options: {
+                root: HTMLElement;
+            },
+        ) {
+            this.callback = callback;
+            this.options = options;
+        }
+
+        observe = (targetNode: HTMLElement) => {
+            observe(targetNode, this.options.root);
+            setTimeout(() => {
+                const entries: Entries = [{ isIntersecting: true }];
+                this.callback(entries);
+            }, 100);
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        disconnect = () => {};
+    };
+
+    it('hook should correctly load next offset options', async () => {
+        const fetchOptions = jest.fn((offset: number) => {
+            return sleep().then(() => {
+                return mockOptions(offset);
+            });
+        });
+
+        let listRef: HTMLElement | null;
+
+        const CustomOptionsList = React.forwardRef<HTMLElement, OptionsListProps>(
+            ({ inputProps, ...props }, ref) => {
+                const inputRef = React.useRef<HTMLInputElement>(null);
+
+                return (
+                    <div>
+                        <div style={{ padding: '5px' }}>
+                            <Input
+                                label='Поиск'
+                                block={true}
+                                ref={inputRef}
+                                dataTestId='input'
+                                {...inputProps}
+                            />
+                        </div>
+                        <OptionsList {...props} ref={ref} />
+                    </div>
+                );
+            },
+        );
+
+        const Component: React.FC = () => {
+            const { optionsProps } = useLazyLoading({
+                limit: LIMIT,
+                optionsFetcher: fetchOptions,
+                skeleton: <Skeleton dataTestId='skeleton' visible={true} />,
+            });
+
+            listRef = optionsProps.optionsListProps.ref.current;
+
+            return (
+                <div style={{ width: 320 }}>
+                    <Select dataTestId='select' {...optionsProps} OptionsList={CustomOptionsList} />
+                </div>
+            );
+        };
+
+        const { getByTestId, getAllByTestId, getAllByText, queryAllByTestId } = render(
+            <Component />,
+        );
+
+        /*
+         * Шаг 1. Открываем селект, проверяем что в списке опций всего LIMIT опций,
+         * которые представляют из себя скелетоны,
+         * и что вызвана функция-фетчер с параметрами
+         * 0 сдвига и LIMIT итемов
+         */
+        await waitFor(() => {
+            getByTestId('select-field').click();
+        });
+        expect(getAllByTestId('skeleton')).toHaveLength(LIMIT);
+        expect(getAllByTestId('select-option')).toHaveLength(LIMIT);
+
+        expect(fetchOptions).toHaveBeenCalledWith(0, LIMIT, '');
+
+        // Шаг 2. Дожидаемся загрузки списка опций. Проверяем, что скелетоны заменены ими.
+        await waitForElementToBeRemoved(() => getAllByTestId('skeleton'), {
+            timeout: TIME_TO_FETCH,
+        }).then(async () => {
+            const opts = getAllByText(content => content.startsWith('Option number'));
+            expect(queryAllByTestId('skeleton')).toHaveLength(0);
+            expect(opts).toHaveLength(LIMIT);
+        });
+
+        /*
+         * Шаг 3. Убедимся, что мы следим за пересечением правильных элементов.
+         */
+        expect(observe).toBeCalledWith(
+            getAllByTestId('select-option')[LIMIT - 1],
+            getByTestId('select-options-list'),
+        );
+
+        /*
+         * Шаг 4.
+         * В моковой "реализации" intersectionObserver'a пересечение этих блоков (скролл
+         * до последней опции) имитируется через 100ms после шага 3.
+         * Проверим, что уже загруженные опции никуда не пропали,
+         * и то, что к ним добавилось LIMIT скелетонов, индицирующие загрузку следующего офсета.
+         * Также проверим, что функция-фетчер вызвалась с обновленными
+         * параметрами (offset = 1, LIMIT не изменился)
+         */
+        await waitFor(() => {
+            expect(getAllByTestId('select-option')).toHaveLength(LIMIT * 2);
+
+            expect(getAllByTestId('skeleton')).toHaveLength(LIMIT);
+            const oldOpts = getAllByText(content => content.startsWith('Option number'));
+            expect(oldOpts).toHaveLength(LIMIT);
+
+            expect(fetchOptions).toHaveBeenCalledWith(1, LIMIT, '');
+        });
+
+        /*
+         * Шаг 5. После загрузки снова проверяем, пропали ли текущие скелетоны,
+         * и то, что новые опции успешно добавились к старым, теперь представляя один список
+         */
+        await waitForElementToBeRemoved(() => getAllByTestId('skeleton'), {
+            timeout: TIME_TO_FETCH * 2,
+        }).then(async () => {
+            expect(queryAllByTestId('skeleton')).toHaveLength(0);
+        });
+
+        await waitFor(() => {
+            expect(getAllByTestId('select-option')).toHaveLength(LIMIT * 2);
+            const newOpts = getAllByText(content => content.startsWith('Option number'));
+            expect(newOpts).toHaveLength(LIMIT * 2);
+        });
+
+        /*
+         * Шаг 6. Кратко проверим, что флоу подгрузки новых опций (шаги 3-5) отрабатывают и дальше.
+         */
+        await waitFor(() => {
+            expect(getAllByTestId('skeleton')).toHaveLength(LIMIT);
+            expect(fetchOptions).toHaveBeenCalledWith(2, LIMIT, '');
+        });
+
+        /*
+         * Шаг 7. Теперь, когда уже мы уже трижды добавили опции в селект (1 раз при открытии и
+         * 2 раза в результате скролла),
+         * Нужно убедиться, что, если функция-фетчер вернет hasMore: false,
+         * То обсервер перестанет навешиваться - тем самым флоу подгрузки новых опций прервется.
+         * В моковой функции флаг hasMore вернет false, при оффсете 2 и больше
+         * (этот самый момент, текущий оффсет == 2)
+         */
+
+        await waitFor(() => {
+            expect(queryAllByTestId('skeleton')).toHaveLength(0);
+            expect(fetchOptions).toBeCalledTimes(3);
+        });
+
+        /*
+         * Шаг 8. Проверим, что изменение инпута внутри кастомного OptionsList затирает текущие
+         * опции и обновляет значение офсета, а также что функция-фетчер вызывается с параметром
+         * поиска по этой самой строке
+         */
+
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        listRef.scrollTo = jest.fn();
+
+        const input = getByTestId('input') as HTMLInputElement;
+
+        fireEvent.change(input, { target: { value: 'Query' } });
+        await waitFor(() => {
+            expect(getAllByTestId('skeleton')).toHaveLength(LIMIT);
+            expect(getAllByTestId('select-option')).toHaveLength(LIMIT);
+            expect(fetchOptions).toHaveBeenCalledWith(0, LIMIT, 'Query');
+            expect(listRef?.scrollTo).toHaveBeenCalledWith({ top: 0 });
+        });
+    });
+});

--- a/packages/select/src/presets/useLazyLoading/use-lazy-loading.test.tsx
+++ b/packages/select/src/presets/useLazyLoading/use-lazy-loading.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { fireEvent, render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 
-import { OptionsList, Select, useLazyLoading } from '../../index';
-import { Skeleton } from '../../../../skeleton';
-import { Input } from '../../../../input';
-import { OptionsListProps } from '../../../../picker-button/dist/Component-2e5019e8';
+import { Skeleton } from '@alfalab/core-components-skeleton';
+import { Input } from '@alfalab/core-components-input';
+import { OptionsList, OptionsListProps, Select, useLazyLoading } from '../../index';
 
 const LIMIT = 10;
 const TIME_TO_FETCH = 250;

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -8,6 +8,7 @@ import {
     ReactElement,
 } from 'react';
 import { PopoverProps } from '@alfalab/core-components-popover';
+import { InputProps } from '@alfalab/core-components-input';
 
 export type OptionShape = {
     /**
@@ -440,6 +441,11 @@ export type OptionsListProps = {
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
+
+    /**
+     * Дополнительные пропсы для Input'a, находящегося внутри кастомного OptionsList
+     */
+    inputProps?: InputProps;
 };
 
 export type OptgroupProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13126,6 +13126,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intersection-observer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.0.tgz#6c84628f67ce8698e5f9ccf857d97718745837aa"
+  integrity sha512-2Vkz8z46Dv401zTWudDGwO7KiGHNDkMv417T5ItcNYfmvHR/1qCTVBO9vwH8zZmQ0WkA/1ARwpysR9bsnop4NQ==
+
 into-stream@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"


### PR DESCRIPTION
# Опишите проблему

- Требуется поддержка ленивой загрузки для опций в селекте. 
- При доскролливании текущей "страницы" опций (попадание в поле видимости последнего элемента) - должна загружаться следующая
- Загружаемые в данный опции отображаются как скелетоны (кастомизируется)
- Должно быть невозможно начать загрузку следующей страницы, пока не загрузилась текущая

- Также необходима возможность поддержать поиск по опциям в этой самой ленивой загрузке (искать по фильтру)
- При открытии селекта автофокус в поле ввода
- При изменении данных в поле ввода удалять текущии опции и загружать новые

- Уже загруженные опции и состояние инпута поиска должны сохранятся, если селект закрылся.
- Если список опций, возможных для загрузки закончился, необходимо перестать запрашивать новые.


Реализовано через расшаренный хук, добавлен пресет для использования lazyload как с поиском, так и без него, покрыл юнитом

Добавлен полифилл intersection-observer для работы в ie 

# Визуально посмотреть, как работает, можно по

 [гифке раз](https://p52.f0.n0.cdn.getcloudapp.com/items/d5uAoDyW/5b11857d-3fb2-480b-8ca3-06a25ae98725.gif?source=viewer&v=b2b26ab5117624b15127f77c7fb9827d)
, [гифке два](https://p52.f0.n0.cdn.getcloudapp.com/items/wbu6GLv8/3c88ce1c-540d-4b23-ad13-6bbb79778b35.gif?source=viewer&v=8e7e21098962bf980e19557d6df224a9)
