### PR TITLE
Доработки IntlPhoneInput

### DIFF
--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -13,6 +13,7 @@ import { CountriesSelect } from './components';
 import styles from './index.module.css';
 import { formatPhoneWithUnclearableCountryCode } from './utils/format-phone-with-unclearable-country-code';
 import { useCaretAvoidCountryCode } from './useCaretAvoidCountryCode';
+import { usePreventCaretReset } from './usePreventCaretReset';
 
 const countriesHash = getCountriesHash();
 
@@ -238,6 +239,7 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
         const countryCodeLength = `+${country.dialCode}`.length;
 
         useCaretAvoidCountryCode({ inputRef, countryCodeLength, clearableCountryCode });
+        usePreventCaretReset({ inputRef, countryCodeLength, clearableCountryCode });
 
         return (
             <InputAutocomplete

--- a/packages/intl-phone-input/src/usePreventCaretReset.ts
+++ b/packages/intl-phone-input/src/usePreventCaretReset.ts
@@ -1,0 +1,45 @@
+import { RefObject, useCallback, useEffect } from 'react';
+
+type Args = {
+    inputRef: RefObject<HTMLInputElement>;
+    countryCodeLength: number;
+    clearableCountryCode: boolean;
+};
+
+export function usePreventCaretReset({ inputRef, clearableCountryCode, countryCodeLength }: Args) {
+    const handleDeleteChar = useCallback(
+        (event: KeyboardEvent) => {
+            const input = event.target as HTMLInputElement;
+            const caretPosition = input.selectionStart;
+
+            if (event.key !== 'Backspace' || !caretPosition) return;
+
+            if (!clearableCountryCode && caretPosition <= countryCodeLength) {
+                event.preventDefault();
+
+                return;
+            }
+
+            const newPosition = caretPosition - 1;
+
+            requestAnimationFrame(() => {
+                input.setSelectionRange(newPosition, newPosition);
+            });
+        },
+        [clearableCountryCode, countryCodeLength],
+    );
+
+    useEffect(() => {
+        const input = inputRef.current;
+
+        if (!input) return;
+
+        input.addEventListener('keydown', handleDeleteChar);
+
+        // eslint-disable-next-line consistent-return
+        return () => {
+            input.removeEventListener('keydown', handleDeleteChar);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [handleDeleteChar]);
+}

--- a/packages/intl-phone-input/src/utils/format-phone-with-unclearable-country-code.test.ts
+++ b/packages/intl-phone-input/src/utils/format-phone-with-unclearable-country-code.test.ts
@@ -16,11 +16,10 @@ describe('formatPhoneWithUnclearableCountryCode', () => {
         } as Country;
 
         expect(formatPhoneWithUnclearableCountryCode('', az)).toEqual('+994');
-        expect(formatPhoneWithUnclearableCountryCode('+', az)).toEqual('+994');
-        expect(formatPhoneWithUnclearableCountryCode('+9', az)).toEqual('+994');
+        expect(formatPhoneWithUnclearableCountryCode('6', az)).toEqual('+994 6');
+        expect(formatPhoneWithUnclearableCountryCode('9', az)).toEqual('+994 9');
         expect(formatPhoneWithUnclearableCountryCode('+99', az)).toEqual('+994');
         expect(formatPhoneWithUnclearableCountryCode('+994', az)).toEqual('+994');
-        expect(formatPhoneWithUnclearableCountryCode('1+994', az)).toEqual('+994');
         expect(formatPhoneWithUnclearableCountryCode('+9941', az)).toEqual('+9941');
     });
 });

--- a/packages/intl-phone-input/src/utils/format-phone-with-unclearable-country-code.ts
+++ b/packages/intl-phone-input/src/utils/format-phone-with-unclearable-country-code.ts
@@ -17,5 +17,9 @@ export const formatPhoneWithUnclearableCountryCode = (phone: string, country: Co
         return phone.replace(RUSSIAN_NATIONAL_DIAL_CODE, countryPrefix);
     }
 
-    return countryPrefix;
+    if (countryPrefix.startsWith(phone) || !phone) {
+        return countryPrefix;
+    }
+
+    return `${countryPrefix} ${phone}`;
 };


### PR DESCRIPTION
* Каретка прыгает в конец строки при удалении символа
* Хочется чтобы при выделении кода страны (вариант с нестираемым кодом страны) и вводе цифры мобильного он появлялась после кода страны(как в phoneInput). На данный момент вводимая цифра игнорируется 

Шаги для воспроизведения:
1. Перейти во вкладку "Платежи и переводы" -> "Мобильная связь"
2. Ввести полностью номер телефона
3. Удалить не последний символ из номера

Ожидаемый результат: удалится символ, каретка останется на его месте
Фактический результат: удалится символ, каретка переместится в конец строки

P.S. По наблюдению, баг вопроизводится только при условии, что введено 7+ цифр (например если ввести +7 999 999 и удалить символ, то все придет к ожидаемому результату, а если ввести +7 999 999 9... , то баг воспроизведется)