### PR TITLE
fix(select): remove wron prop passed into renderOption method

### DIFF
--- a/packages/select/src/presets/useLazyLoading/hook.tsx
+++ b/packages/select/src/presets/useLazyLoading/hook.tsx
@@ -251,9 +251,7 @@ export function useLazyLoading({
     );
 
     const renderOption = useCallback(
-        props => (
-            <Option {...props} Checkmark={null} highlighted={loading ? false : props.highlighted} />
-        ),
+        props => <Option {...props} highlighted={loading ? false : props.highlighted} />,
         [loading],
     );
 


### PR DESCRIPTION
Небольшой фикс: неверно была проставлена пропса, из-за которой выбранная опция никогда не будет индицироваться
