### PR TITLE
feat(intl-phone-input): hide select for countries when one country

### DIFF
--- a/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
+++ b/packages/intl-phone-input/src/__snapshots__/component.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`IntlPhoneInput should match snapshot 1`] = `
               aria-haspopup="listbox"
               aria-owns="downshift-3-menu"
               class="component"
+              data-test-id="countries-select"
               role="combobox"
               tabindex="-1"
             >

--- a/packages/intl-phone-input/src/component.test.tsx
+++ b/packages/intl-phone-input/src/component.test.tsx
@@ -177,4 +177,23 @@ describe('IntlPhoneInput', () => {
             expect(input).toHaveValue('+7');
         });
     });
+
+    it('should not show country select when one country is available', async () => {
+        const countries = [
+            {
+                areaCodes: null,
+                dialCode: '7',
+                iso2: 'ru',
+                name: 'Россия',
+                priority: 0,
+            },
+        ];
+        const { queryByTestId } = render(
+            <IntlPhoneInput value='+7' countries={countries} onChange={() => null} />,
+        );
+
+        const countrySelect = queryByTestId('countries-select');
+
+        expect(countrySelect).toBeNull();
+    });
 });

--- a/packages/intl-phone-input/src/component.tsx
+++ b/packages/intl-phone-input/src/component.tsx
@@ -260,7 +260,7 @@ export const IntlPhoneInput = forwardRef<HTMLInputElement, IntlPhoneInputProps>(
                     colors,
                     className: cn(className, styles[size]),
                     addonsClassName: styles.addons,
-                    leftAddons: (
+                    leftAddons: countries.length > 1 && (
                         <CountriesSelect
                             disabled={disabled || readOnly}
                             size={size}

--- a/packages/intl-phone-input/src/components/select/component.tsx
+++ b/packages/intl-phone-input/src/components/select/component.tsx
@@ -10,7 +10,10 @@ import { FlagIcon } from '../flag-icon';
 
 import styles from './index.module.css';
 
-type CountriesSelectProps = Pick<SelectProps, 'size' | 'disabled' | 'onChange' | 'preventFlip'> & {
+type CountriesSelectProps = Pick<
+    SelectProps,
+    'size' | 'dataTestId' | 'disabled' | 'onChange' | 'preventFlip'
+> & {
     selected: string;
     countries: Country[];
     fieldWidth: number | null;
@@ -24,6 +27,7 @@ export const CountriesSelect: FC<CountriesSelectProps> = ({
     fieldWidth,
     preventFlip,
     onChange,
+    dataTestId = 'countries-select',
 }) => {
     const options = useMemo(
         () =>
@@ -56,6 +60,7 @@ export const CountriesSelect: FC<CountriesSelectProps> = ({
     return (
         <div className={styles.component} onClick={event => event.stopPropagation()}>
             <Select
+                dataTestId={dataTestId}
                 disabled={disabled}
                 size={size}
                 options={options}


### PR DESCRIPTION
# Опишите проблему
В компоненте IntlPhoneInput не показываем селект со странами, когда страна одна

# Шаги для воспроизведения
1. Перейти на страницу '...'
2. Нажать на кнопку '...'

# Ожидаемое поведение
При нажатии на кнопку должно появится модальное окно

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10

## Смартфон (если данных нет оставте блок пустым):
 - Device: iPhone 6
 - OS: iOS 10
 - Browser: Chrome
 - Version: 65

# Дополнительная информация
Дополнительная информация
