### PR TITLE
feat(collapse): use css-transition

### DIFF
--- a/packages/collapse/package.json
+++ b/packages/collapse/package.json
@@ -21,6 +21,9 @@
         "@alfalab/core-components-link": "^3.2.0",
         "@alfalab/icons-classic": "^1.74.0",
         "classnames": "^2.2.6",
-        "lodash.debounce": "^4.0.8"
+        "react-transition-group": "^4.3.0"
+    },
+    "devDependencies": {
+      "@types/react-transition-group": "^4.2.4"
     }
 }

--- a/packages/collapse/src/Component.test.tsx
+++ b/packages/collapse/src/Component.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { render } from '@testing-library/react';
+import React, { ReactElement } from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
-import { Collapse } from './index';
+import { Collapse, CollapseProps } from './index';
 
 const paragraph = (
     <p style={{ margin: '0 0 16px 0' }}>
@@ -27,6 +27,55 @@ describe('Collapse', () => {
             );
 
             expect(container).toMatchSnapshot();
+        });
+
+        it('should call onExpandedChange prop when clicked', () => {
+            const handleExpandedChange = jest.fn();
+
+            render(
+                <Collapse
+                    collapsedLabel='подробнее'
+                    expanded={false}
+                    onExpandedChange={handleExpandedChange}
+                >
+                    {paragraph}
+                </Collapse>,
+            );
+
+            fireEvent.click(screen.getByText(/подробнее/i));
+            expect(handleExpandedChange).toHaveBeenCalledTimes(1);
+        });
+
+        beforeAll(() => {
+            jest.useFakeTimers();
+        });
+
+        afterAll(() => {
+            jest.clearAllTimers();
+        });
+
+        it('should call onAnimationStart and onAnimationStart props', () => {
+            const onAnimationStart = jest.fn();
+            const onAnimationEnd = jest.fn();
+            const enteringTransitionDuration = 300;
+
+            const collapse = (props: Partial<CollapseProps>, children: ReactElement) => (
+                <Collapse {...props}>{children}</Collapse>
+            );
+
+            const defaultProps = {
+                collapsedLabel: 'подробнее',
+                onAnimationStart,
+                onAnimationEnd,
+                expanded: false,
+            };
+
+            const { rerender } = render(collapse(defaultProps, paragraph));
+            rerender(collapse({ ...defaultProps, expanded: true }, paragraph));
+
+            expect(onAnimationStart).toHaveBeenCalledTimes(1);
+            jest.advanceTimersByTime(enteringTransitionDuration);
+            expect(onAnimationEnd).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/packages/collapse/src/Component.tsx
+++ b/packages/collapse/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useRef, useState, useMemo } from 'react';
+import React, { forwardRef, useCallback, useRef, useState, useMemo, CSSProperties } from 'react';
 import cn from 'classnames';
 import { ArrowDownMBlackIcon } from '@alfalab/icons-classic/ArrowDownMBlackIcon';
 import { ArrowUpMBlackIcon } from '@alfalab/icons-classic/ArrowUpMBlackIcon';
@@ -134,6 +134,23 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
             if (onExpandedChange) onExpandedChange();
         }, [isExpanded, onExpandedChange, uncontrolled]);
 
+        const handleTransitionEnd = useCallback(() => {
+            if (contentRef.current) {
+                if (contentRef.current.offsetHeight > 0) {
+                    contentRef.current.style.height = 'auto';
+                }
+            }
+        }, []);
+
+
+        const contentStyles: CSSProperties = useMemo(() => {
+            const contentHeight = contentRef.current?.offsetHeight;
+
+            return {
+                height: isExpanded && !contentHeight ? '0px' : `${contentHeight}px`,
+            };
+        }, [isExpanded]);
+
         return (
             <div
                 ref={ref}
@@ -150,8 +167,17 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
                     timeout={300}
                     classNames={transitionClassNames}
                 >
-                    <div ref={contentRef} className={contentClassName}>
-                        <div ref={contentCaseRef}>{children}</div>
+                    <div ref={contentRef}
+                         className={contentClassName}
+                         onTransitionEnd={handleTransitionEnd}
+                         style={contentStyles}
+                    >
+                        <div
+                            ref={contentCaseRef}
+                            className={styles.contentCase}
+                        >
+                            {children}
+                        </div>
                     </div>
                 </CSSTransition>
                 {(expandedLabel || collapsedLabel) && (

--- a/packages/collapse/src/Component.tsx
+++ b/packages/collapse/src/Component.tsx
@@ -122,7 +122,7 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
             [styles.collapsed]: !isExpanded,
         });
 
-        const labelClassName = isExpanded ? styles.expandedLabel : '';
+        const labelClassName = cn(styles.label, isExpanded ? styles.expandedLabel : '');
 
         const ToggledIcon = isExpanded ? ArrowUpMBlackIcon : ArrowDownMBlackIcon;
 
@@ -141,7 +141,6 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
                 }
             }
         }, []);
-
 
         const contentStyles: CSSProperties = useMemo(() => {
             const contentHeight = contentRef.current?.offsetHeight;
@@ -167,15 +166,13 @@ export const Collapse = forwardRef<HTMLDivElement, CollapseProps>(
                     timeout={300}
                     classNames={transitionClassNames}
                 >
-                    <div ref={contentRef}
-                         className={contentClassName}
-                         onTransitionEnd={handleTransitionEnd}
-                         style={contentStyles}
+                    <div
+                        ref={contentRef}
+                        className={contentClassName}
+                        onTransitionEnd={handleTransitionEnd}
+                        style={contentStyles}
                     >
-                        <div
-                            ref={contentCaseRef}
-                            className={styles.contentCase}
-                        >
+                        <div ref={contentCaseRef} className={styles.contentCase}>
                             {children}
                         </div>
                     </div>

--- a/packages/collapse/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/collapse/src/__snapshots__/Component.test.tsx.snap
@@ -6,8 +6,7 @@ exports[`Collapse Display tests should display radio group with one child correc
     class="collapse"
   >
     <div
-      class="content"
-      style="height: 0px;"
+      class="content collapsed"
     >
       <div>
         <p
@@ -63,8 +62,7 @@ exports[`Collapse Display tests should display with children like boolean or str
     class="collapse"
   >
     <div
-      class="content"
-      style="height: 0px;"
+      class="content collapsed"
     >
       <div>
         <p

--- a/packages/collapse/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/collapse/src/__snapshots__/Component.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`Collapse Display tests should display radio group with one child correc
     <div
       class="content collapsed"
     >
-      <div>
+      <div
+        class="contentCase"
+      >
         <p
           style="margin: 0px 0px 16px 0px;"
         >
@@ -64,7 +66,9 @@ exports[`Collapse Display tests should display with children like boolean or str
     <div
       class="content collapsed"
     >
-      <div>
+      <div
+        class="contentCase"
+      >
         <p
           style="margin: 0px 0px 16px 0px;"
         >

--- a/packages/collapse/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/collapse/src/__snapshots__/Component.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Collapse Display tests should display radio group with one child correc
       </div>
     </div>
     <a
-      class="component primary pseudo withAddons"
+      class="component primary pseudo withAddons label"
     >
       <span>
         <span

--- a/packages/collapse/src/index.module.css
+++ b/packages/collapse/src/index.module.css
@@ -13,14 +13,30 @@
 .content {
     position: relative;
     overflow: hidden;
-    visibility: hidden;
-    height: 0;
-    transition: height 0.2s;
 }
 
-.expandedContent {
-    visibility: visible;
+.enter {
+    height: 0;
+}
+
+.enterActive,
+.enterDone {
     height: auto;
+    transition: height 300ms ease-in-out;
+}
+
+.exit {
+    height: auto;
+}
+
+.exitActive,
+.exitDone {
+    height: 0;
+    transition: height 300ms ease-in-out;
+}
+
+.collapsed {
+    height: 0;
 }
 
 .expandedLabel {

--- a/packages/collapse/src/index.module.css
+++ b/packages/collapse/src/index.module.css
@@ -42,3 +42,7 @@
 .expandedLabel {
     margin-top: 15px;
 }
+
+.contentCase {
+    overflow: hidden;
+}

--- a/packages/collapse/src/index.module.css
+++ b/packages/collapse/src/index.module.css
@@ -39,6 +39,10 @@
     height: 0;
 }
 
+.label {
+    transition: margin-top 300ms ease-in-out;
+}
+
 .expandedLabel {
     margin-top: 15px;
 }


### PR DESCRIPTION
# Опишите проблему
- Изменены стили transition в Collapse на более плавное разворачивание и сворачивание
- Collapse переведен на css transition, добавлена возможность прокидывать хендлеры onAnimationStart и onAnimationEnd (используются в компоненте в библиотеке нового клика)
