### PR TITLE
fix(input): move caret to end on focus

### DIFF
--- a/packages/input/src/Component.tsx
+++ b/packages/input/src/Component.tsx
@@ -230,6 +230,12 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     setFocused(true);
                 }
 
+                const input = event.currentTarget;
+
+                setTimeout(() => {
+                    input.setSelectionRange(input.value.length, input.value.length);
+                }, 0);
+
                 if (onFocus) {
                     onFocus(event);
                 }
@@ -260,6 +266,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             },
             [onChange, uncontrolled],
         );
+
+
 
         const handleClear = useCallback(
             (event: MouseEvent<HTMLButtonElement>) => {

--- a/packages/input/src/utils.ts
+++ b/packages/input/src/utils.ts
@@ -1,0 +1,22 @@
+import { MouseEvent } from 'react';
+
+export function isPaddingClick(element: HTMLElement, event: MouseEvent<HTMLElement>) {
+    const style = getComputedStyle(element, null);
+
+    const intValue = (property: string) => +style.getPropertyValue(property).replace('px', '');
+
+    const pTop = intValue('padding-top');
+    const pRight = intValue('padding-right');
+    const pLeft = intValue('padding-left');
+    const pBottom = intValue('padding-bottom');
+
+    const width = element.offsetWidth;
+    const height = element.offsetHeight;
+
+    const x = event.nativeEvent.offsetX;
+    const y = event.nativeEvent.offsetY;
+
+    const clickedInside = x > pLeft && x < width - pRight && y > pTop && y < height - pBottom;
+
+    return !clickedInside;
+}


### PR DESCRIPTION
В инпутах с паддингами, клик по верхней границе ставит каретку в начало инпута, что не очень круто. Хотим улучшить UX

Нормально сделать это нельзя :(

Есть вариант двигать каретку при фокусе. Тут есть нюансы:
— Если инпут уже в фокусе, то при клике каретка все равно будет перемещаться в начало
— Видно, как каретка прыгает

Если делать по клику:
— Видно, как каретка прыгает
— Меняется выделение по дабл-клику