### PR TITLE
feat(icon-button): added 'target' attribute, when IconButton is link

### DIFF
--- a/packages/button/src/Component.tsx
+++ b/packages/button/src/Component.tsx
@@ -57,11 +57,6 @@ export type ComponentProps = {
     href?: AnchorHTMLAttributes<HTMLAnchorElement>['href'];
 
     /**
-     * Аттрибут target для ссылок в виде кнопки
-     */
-    target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
-
-    /**
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
@@ -105,7 +100,6 @@ export const Button = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, Bu
             className,
             dataTestId,
             href,
-            target,
             loading = false,
             nowrap = false,
             colors = 'default',
@@ -179,9 +173,10 @@ export const Button = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, Bu
         }, []);
 
         if (href) {
+            const { target } = restProps as AnchorHTMLAttributes<HTMLAnchorElement>;
+
             return (
                 <a
-                    target={target || '_blank'}
                     rel={target === '_blank' ? 'noreferrer noopener' : undefined}
                     {...componentProps}
                     {...(restProps as AnchorHTMLAttributes<HTMLAnchorElement>)}

--- a/packages/button/src/Component.tsx
+++ b/packages/button/src/Component.tsx
@@ -57,6 +57,11 @@ export type ComponentProps = {
     href?: AnchorHTMLAttributes<HTMLAnchorElement>['href'];
 
     /**
+     * Аттрибут target для ссылок в виде кнопки
+     */
+    target?: AnchorHTMLAttributes<HTMLAnchorElement>['target'];
+
+    /**
      * Идентификатор для систем автоматизированного тестирования
      */
     dataTestId?: string;
@@ -100,6 +105,7 @@ export const Button = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, Bu
             className,
             dataTestId,
             href,
+            target,
             loading = false,
             nowrap = false,
             colors = 'default',
@@ -173,10 +179,9 @@ export const Button = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, Bu
         }, []);
 
         if (href) {
-            const { target } = restProps as AnchorHTMLAttributes<HTMLAnchorElement>;
-
             return (
                 <a
+                    target={target || '_blank'}
                     rel={target === '_blank' ? 'noreferrer noopener' : undefined}
                     {...componentProps}
                     {...(restProps as AnchorHTMLAttributes<HTMLAnchorElement>)}

--- a/packages/icon-button/src/Component.tsx
+++ b/packages/icon-button/src/Component.tsx
@@ -43,7 +43,8 @@ export type IconButtonProps = {
      */
     colors?: 'default' | 'inverted';
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size'> &
-    Pick<ButtonProps, 'href' | 'target' | 'loading'>;
+    Pick<ButtonProps, 'href' | 'loading'> &
+    Pick<HTMLAnchorElement, 'target'>;
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     (

--- a/packages/icon-button/src/Component.tsx
+++ b/packages/icon-button/src/Component.tsx
@@ -43,7 +43,7 @@ export type IconButtonProps = {
      */
     colors?: 'default' | 'inverted';
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size'> &
-    Pick<ButtonProps, 'href' | 'loading'>;
+    Pick<ButtonProps, 'href' | 'target' | 'loading'>;
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     (

--- a/packages/icon-button/src/Component.tsx
+++ b/packages/icon-button/src/Component.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, ElementType, forwardRef } from 'react';
+import React, { AnchorHTMLAttributes, ButtonHTMLAttributes, ElementType, forwardRef } from 'react';
 import cn from 'classnames';
 
 import { Button, ButtonProps } from '@alfalab/core-components-button';
@@ -44,7 +44,7 @@ export type IconButtonProps = {
     colors?: 'default' | 'inverted';
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'size'> &
     Pick<ButtonProps, 'href' | 'loading'> &
-    Pick<HTMLAnchorElement, 'target'>;
+    Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'target'>;
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     (


### PR DESCRIPTION
Previously, if you use IconButton like link - TS used to swear at the absence of the 'target'
property of IconButton.

# Опишите проблему
При нажатии на кнопку 'создать отчет' ничего не происходит

# Шаги для воспроизведения
1. Перейти на страницу '...'
2. Нажать на кнопку '...'

# Ожидаемое поведение
При нажатии на кнопку должно появится модальное окно

# Чек лист
- [ ] Тесты
- [ ] Документация

# Внешний вид

Ожидаемый        | Фактический
:---------------:|:--------------------|
** Ожидаемый  ** | ** Фактический    **|

# Тестовый стенд

## Десктоп (если данных нет оставте блок пустым):
 - OS: MacOS
 - Browser: Safari
 - Version: 10

## Смартфон (если данных нет оставте блок пустым):
 - Device: iPhone 6
 - OS: iOS 10
 - Browser: Chrome
 - Version: 65

# Дополнительная информация
Дополнительная информация
