### PR TITLE
feat(file-upload-item): add download prop

### DIFF
--- a/packages/file-upload-item/src/Component.test.tsx
+++ b/packages/file-upload-item/src/Component.test.tsx
@@ -8,6 +8,7 @@ export const fileProps = {
     uploadDate: '22.01.2018',
     size: 45000,
     downloadLink: '/link',
+    download: 'новое_название_файла',
     uploadStatus: 'SUCCESS' as FileStatuses,
     showDelete: true,
 };

--- a/packages/file-upload-item/src/Component.tsx
+++ b/packages/file-upload-item/src/Component.tsx
@@ -46,6 +46,12 @@ export type FileUploadItemProps = {
     downloadLink?: string;
 
     /**
+     * Рекомендует браузеру скачивать контент по ссылке.
+     * В проп может быть передано рекомендуемое название скачиваемого файла.
+     */
+    download?: string | true;
+
+    /**
      * Отображение кнопки удаления
      */
     showDelete?: boolean;
@@ -104,6 +110,7 @@ export const FileUploadItem: React.FC<FileUploadItemProps> = ({
     size,
     uploadDate,
     downloadLink,
+    download,
     uploadStatus,
     uploadPercent = 0,
     error = uploadStatus === 'ERROR' ? 'Не удалось загрузить файл' : undefined,
@@ -152,7 +159,12 @@ export const FileUploadItem: React.FC<FileUploadItemProps> = ({
         () => (
             <div className={styles.name}>
                 {downloadLink ? (
-                    <Link pseudo={true} href={downloadLink} onClick={handleDownload}>
+                    <Link
+                        pseudo={true}
+                        href={downloadLink}
+                        onClick={handleDownload}
+                        download={download}
+                    >
                         {name}
                     </Link>
                 ) : (
@@ -160,7 +172,7 @@ export const FileUploadItem: React.FC<FileUploadItemProps> = ({
                 )}
             </div>
         ),
-        [downloadLink, handleDownload, name],
+        [downloadLink, handleDownload, download, name],
     );
 
     const showMeta = !showRestore && (!uploadStatus || uploadStatus === 'SUCCESS');

--- a/packages/file-upload-item/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/file-upload-item/src/__snapshots__/Component.test.tsx.snap
@@ -31,6 +31,7 @@ Object {
           >
             <a
               class="component primary pseudo"
+              download="новое_название_файла"
               href="/link"
             >
               <span
@@ -110,6 +111,7 @@ Object {
         >
           <a
             class="component primary pseudo"
+            download="новое_название_файла"
             href="/link"
           >
             <span


### PR DESCRIPTION
# Проблема
В компоненте file-upload-item есть возможность указать ссылку для скачивания файла, но нет возможности указать желаемое имя скачиваемого файла. Да и вообще не устанавливается атрибут download на ссылку.
