### PR TITLE
feat(confirmation): compact code-input if slotsCount > 6

### DIFF
--- a/packages/confirmation/src/__image_snapshots__/confirmation-interactions-tests-open-don-t-receive-sms-snap.png
+++ b/packages/confirmation/src/__image_snapshots__/confirmation-interactions-tests-open-don-t-receive-sms-snap.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f657adc48ca6fa99d8da38d4ef6226dc46dda2aced95ed1c5e3bf78979fb361e
-size 31647
+oid sha256:2b32174f3bd9871b4ac4baaa24ab0d7cd3b27522d3c52235e592fcbc5b79d250
+size 31645

--- a/packages/confirmation/src/components/code-input/component.tsx
+++ b/packages/confirmation/src/components/code-input/component.tsx
@@ -217,6 +217,7 @@ export const CodeInput = forwardRef<HTMLInputElement, CodeInputProps>(
             <div
                 className={cn(styles.component, className, {
                     [styles.shake]: Boolean(error),
+                    [styles.compact]: slotsCount > 6,
                 })}
             >
                 {new Array(slotsCount).fill('').map((_, index) => (

--- a/packages/confirmation/src/components/code-input/index.module.css
+++ b/packages/confirmation/src/components/code-input/index.module.css
@@ -38,6 +38,11 @@
     }
 }
 
+.compact .input {
+    width: 28px;
+    height: 40px;
+}
+
 @keyframes shake {
     0% {
         transform: translateX(0);

--- a/packages/confirmation/src/docs/Component.stories.mdx
+++ b/packages/confirmation/src/docs/Component.stories.mdx
@@ -124,7 +124,7 @@ import vars from '!!raw-loader!../vars.css';
                             maxWidth: '375px',
                             margin: '16px 0 0',
                             padding: '16px',
-                            border: '1px solid #eeeff1',
+                            boxShadow: '0 0 0 1px #eeeff1',
                             boxSizing: 'border-box'
                         }}
                     >


### PR DESCRIPTION
Код из 8 символов не влезает на мобилках, делаем его более компактным