### PR TITLE
fix(modal): Fix spreading backdrop props to BaseModal component

### DIFF
--- a/packages/modal/src/Component.desktop.tsx
+++ b/packages/modal/src/Component.desktop.tsx
@@ -82,6 +82,7 @@ const ModalDesktopComponent = forwardRef<HTMLDivElement, ModalDesktopProps>(
                 })}
                 className={cn(styles.component, className, !fullscreen && styles[size])}
                 backdropProps={{
+                    ...restProps.backdropProps,
                     invisible: fullscreen,
                 }}
                 transitionProps={{

--- a/packages/modal/src/Component.mobile.tsx
+++ b/packages/modal/src/Component.mobile.tsx
@@ -40,6 +40,7 @@ const ModalMobileComponent = forwardRef<HTMLDivElement, ModalMobileProps>(
                 }}
                 className={cn(className, styles.component)}
                 backdropProps={{
+                    ...restProps.backdropProps,
                     invisible: true,
                 }}
             >


### PR DESCRIPTION
# Опишите проблему
Нельзя задать className для Backdrop компонента Modal