### PR TITLE
feat(select): add zIndexPopover property

### DIFF
--- a/packages/select/src/components/base-select/Component.tsx
+++ b/packages/select/src/components/base-select/Component.tsx
@@ -72,6 +72,7 @@ export const BaseSelect = forwardRef(
             Optgroup = () => null,
             Option = () => null,
             updatePopover,
+            zIndexPopover,
             showEmptyOptionsList = false,
             visibleOptions,
         }: BaseSelectProps,
@@ -422,6 +423,7 @@ export const BaseSelect = forwardRef(
                         preventFlip={preventFlip}
                         popperClassName={styles.popoverInner}
                         update={updatePopover}
+                        zIndex={zIndexPopover}
                     >
                         {needRenderOptionsList && (
                             <div

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -279,6 +279,11 @@ export type BaseSelectProps = {
     updatePopover?: PopoverProps['update'];
 
     /**
+     * z-index поповера
+     */
+    zIndexPopover?: PopoverProps['zIndex'];
+
+    /**
      * Показывать OptionsList, если он пустой
      */
     showEmptyOptionsList?: boolean;


### PR DESCRIPTION
Добавил настройку z-index для поповера

Необходима для совместимости с компонентами arui-feather
Например, у sidebar'а из arui-feather по умолчанию [z-index=1001](https://github.com/alfa-laboratory/arui-feather/blob/master/src/sidebar/sidebar.css#L28)