### PR TITLE
fix: fix classnames hash

### DIFF
--- a/packages/calendar-range/src/Component.tsx
+++ b/packages/calendar-range/src/Component.tsx
@@ -10,7 +10,13 @@ import {
     isCompleteDateInput,
     parseDateString,
 } from '@alfalab/core-components-calendar-input';
-import { isDayButton, ValueState, getCorrectValueState, initialValueState } from './utils';
+import {
+    isDayButton,
+    ValueState,
+    getCorrectValueState,
+    initialValueState,
+    PickPeriod,
+} from './utils';
 
 import { useCalendarMonthes } from './useCalendarMonthes';
 import { useCalendarMaxMinDates } from './useCalendarMaxMinDates';
@@ -77,6 +83,12 @@ export type CalendarRangeProps = {
      * Определяет, как рендерить календарь — в поповере или снизу инпута
      */
     calendarPosition?: 'static' | 'popover';
+
+    /**
+     * Если выбран in-future - будут оторбражаться текущий месяц и следующий
+     * Если выбран in-past - будут оторбражаться текущий месяц и прошлый
+     */
+    pickPeriod?: PickPeriod;
 };
 
 export const CalendarRange: FC<CalendarRangeProps> = ({
@@ -92,6 +104,7 @@ export const CalendarRange: FC<CalendarRangeProps> = ({
     inputToProps = {},
     calendarPosition = 'static',
     dataTestId,
+    pickPeriod = 'in-past',
 }) => {
     const uncontrolled = valueFrom === undefined && valueTo === undefined;
     const isPopover = calendarPosition === 'popover';
@@ -134,6 +147,7 @@ export const CalendarRange: FC<CalendarRangeProps> = ({
         inputValueTo,
         defaultMonth,
         isPopover,
+        pickPeriod,
     });
 
     const handleInputFromChange = useCallback<Required<CalendarInputProps>['onInputChange']>(

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,8 +17,10 @@ import createPackageJson from './tools/rollup/create-package-json';
 import { compiledDarkmodeGenerator } from './tools/rollup/compiled-darkmode-generator';
 
 const currentPackageDir = process.cwd();
+
 const currentPkg = path.join(currentPackageDir, 'package.json');
 
+const rootPkg = require(path.resolve(currentPackageDir, '../../package.json'))
 const pkg = require(currentPkg);
 
 const currentComponentName = pkg.name.replace('@alfalab/core-components-', '');
@@ -46,7 +48,7 @@ const postcssPlugin = postcss({
         generateScopedName: function(name, fileName) {
             const relativeFileName = path.relative(currentPackageDir, fileName);
 
-            const hash = generateClassNameHash(pkg.name, pkg.version, relativeFileName);
+            const hash = generateClassNameHash(pkg.name, rootPkg.version, relativeFileName);
 
             return `${currentComponentName}__${name}_${hash}`;
         },


### PR DESCRIPTION
Сейчас у нас при генерации хэша учитывается версия самого пакета компонента (например, button).
Если изменений в button не было, но была выпущена новая версия root-пакета, то хэш останется тот же самый.

Если на проекте используется `arui-private`, или любая другая библиотека, которая тоже использует `core-components`, и версии `core-components` отличаются, то в общий бандл стилей залетают стили обеих версий библиотеки. В результате этого, некоторые стили могут друг другу переопределять.

Чтобы такого не было, и в бандл залетали стили только одной версии библиотеки, нужно прописать `resolutions` в `package.json`:

```json
"resolutions": {
    "@alfalab/core-components": "нужная версия"
}
```

Если это невозможно по какой-то причине, например у вас разные мажорные версии на проекте и в `arui-private`, то этот реквест решает эту проблему.