### PR TITLE
fix(skeleton): prevent component unmount

### DIFF
--- a/packages/skeleton/src/Component.tsx
+++ b/packages/skeleton/src/Component.tsx
@@ -40,5 +40,5 @@ export const Skeleton: React.FC<SkeletonProps> = ({
         );
     }
 
-    return <React.Fragment>{children}</React.Fragment>;
+    return <div>{children}</div>;
 };

--- a/packages/skeleton/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/skeleton/src/__snapshots__/Component.test.tsx.snap
@@ -73,9 +73,13 @@ exports[`Skeleton Snapshots tests should not display 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    <div />
+    <div>
+      <div />
+    </div>
   </body>,
-  "container": <div />,
+  "container": <div>
+    <div />
+  </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
   "findAllByDisplayValue": [Function],
@@ -135,11 +139,15 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      text
+      <div>
+        text
+      </div>
     </div>
   </body>,
   "container": <div>
-    text
+    <div>
+      text
+    </div>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],


### PR DESCRIPTION
# Мотивация
При переключении видимости компонента Skeleton, его содержимое полностью ре-рендерится. 
Это приводит к тому, что содержащиеся в нем изображения загружаются повторно. Как итог, становится затруднительным поймать момент, когда изображения под скелетоном полностью загружены, так как событие `onLoad` у таких изображений срабатывает дважды.
Причина полного рендера кроется в разных корневых элементах в зависимости от видимости скелетона (`div` / `React.Fragment`). Чтобы этого избежать, в этом PR в обоих случаях используется  `div`

# Шаги для воспроизведения
Демо: https://codesandbox.io/s/skeleton-demo-y7quf . Текущее поведение: событие onLoad выполняется дважды

# Ожидаемое поведение
Событие onLoad выполняется один раз - в конце загрузки изображение