### PR TITLE
Feat/tooltip available height

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
         "intersection-observer": "^0.12.0",
         "libphonenumber-js": "^1.8.4",
         "lodash.debounce": "^4.0.8",
+        "popper-max-size-modifier": "^0.2.0",
         "react-focus-lock": "^2.5.0",
         "react-merge-refs": "^1.1.0",
         "react-node-resolver": "^2.0.1",

--- a/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/picker-button/src/__snapshots__/Component.test.tsx.snap
@@ -112,239 +112,243 @@ exports[`Snapshots tests should display opened correctly 2`] = `
       class="inner popoverInner"
     >
       <div
-        aria-labelledby="downshift-3-label"
-        class="optionsList"
-        id="downshift-3-menu"
-        role="listbox"
-        style="min-width: 0px;"
+        class=""
       >
         <div
-          class="optionsList m"
-          style="height: 0px;"
+          aria-labelledby="downshift-3-label"
+          class="optionsList"
+          id="downshift-3-menu"
+          role="listbox"
+          style="min-width: 0px;"
         >
           <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-0"
-            role="option"
+            class="optionsList m"
+            style="height: 0px;"
           >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-0"
+              role="option"
             >
-              Neptunium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Neptunium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-1"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-1"
+              role="option"
             >
-              Plutonium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Plutonium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-2"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-2"
+              role="option"
             >
-              Americium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Americium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-3"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-3"
+              role="option"
             >
-              Curium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Curium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-4"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-4"
+              role="option"
             >
-              Berkelium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Berkelium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-5"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-5"
+              role="option"
             >
-              Californium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Californium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-6"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-6"
+              role="option"
             >
-              Einsteinium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Einsteinium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-7"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-7"
+              role="option"
             >
-              Fermium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Fermium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-8"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-8"
+              role="option"
             >
-              Mendelevium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Mendelevium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-9"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-9"
+              role="option"
             >
-              Nobelium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Nobelium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-10"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-10"
+              role="option"
             >
-              Lawrencium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Lawrencium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-11"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-11"
+              role="option"
             >
-              Rutherfordium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Rutherfordium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-12"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-12"
+              role="option"
             >
-              Dubnium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Dubnium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-13"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-13"
+              role="option"
             >
-              Seaborgium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Seaborgium
+              </div>
             </div>
-          </div>
-          <div
-            aria-selected="false"
-            class="option m"
-            id="downshift-3-item-14"
-            role="option"
-          >
-            <span
-              class="checkmark"
-            />
             <div
-              class="content textContent"
+              aria-selected="false"
+              class="option m"
+              id="downshift-3-item-14"
+              role="option"
             >
-              Bohrium
+              <span
+                class="checkmark"
+              />
+              <div
+                class="content textContent"
+              >
+                Bohrium
+              </div>
             </div>
           </div>
         </div>

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -24,6 +24,7 @@
         "@alfalab/core-components-stack": "^3.0.1",
         "@popperjs/core": "^2.3.3",
         "classnames": "^2.2.6",
+        "popper-max-size-modifier": "^0.2.0",
         "react-merge-refs": "^1.1.0",
         "react-popper": "^2.2.5",
         "react-transition-group": "^4.3.0",

--- a/packages/popover/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/popover/src/__snapshots__/Component.test.tsx.snap
@@ -19,8 +19,12 @@ Object {
           class="inner"
           style="transition-duration: 150ms;"
         >
-          <div>
-            I am popover
+          <div
+            class=""
+          >
+            <div>
+              I am popover
+            </div>
           </div>
         </div>
       </div>
@@ -98,8 +102,12 @@ Object {
         <div
           class="inner"
         >
-          <div>
-            I am popover
+          <div
+            class=""
+          >
+            <div>
+              I am popover
+            </div>
           </div>
         </div>
       </div>

--- a/packages/popover/src/index.module.css
+++ b/packages/popover/src/index.module.css
@@ -20,6 +20,16 @@
     will-change: transform;
 }
 
+.scrollableContent {
+    position: relative;
+    z-index: 2;
+    overflow-y: auto;
+}
+
+.arrow {
+    z-index: 1;
+}
+
 .arrow:after {
     content: '';
     display: block;

--- a/packages/toast/src/__snapshots__/component.test.tsx.snap
+++ b/packages/toast/src/__snapshots__/component.test.tsx.snap
@@ -53,19 +53,23 @@ exports[`Toast Snapshots tests should math snapshot when prop \`anchorElement\` 
         style="transition-duration: 150ms;"
       >
         <div
-          class="component"
+          class=""
         >
           <div
-            class="contentWrap"
+            class="component"
           >
             <div
-              class="content"
+              class="contentWrap"
             >
-              <div>
-                <div
-                  class="children"
-                >
-                  text
+              <div
+                class="content"
+              >
+                <div>
+                  <div
+                    class="children"
+                  >
+                    text
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/tooltip/src/Component.tsx
+++ b/packages/tooltip/src/Component.tsx
@@ -129,6 +129,16 @@ export type TooltipProps = {
      * Если не передавать, то тултип открывается в противоположном направлении от переданного position.
      */
     fallbackPlacements?: PopoverProps['fallbackPlacements'];
+
+    /**
+     * Запрещает тултипу менять свою позицию, если он не влезает в видимую область.
+     */
+    preventOverflow?: PopoverProps['preventOverflow'];
+
+    /**
+     *  Позволяет тултипу подствраивать свою высоту под границы экрана, если из-за величины контента он выходит за рамки видимой области экрана
+     */
+    availableHeight?: PopoverProps['availableHeight'];
 };
 
 export const Tooltip: FC<TooltipProps> = ({
@@ -153,6 +163,8 @@ export const Tooltip: FC<TooltipProps> = ({
     view = 'tooltip',
     targetRef = null,
     fallbackPlacements,
+    preventOverflow = true,
+    availableHeight = false,
 }) => {
     const [visible, setVisible] = useState(!!forcedOpen);
     const [target, setTarget] = useState<HTMLElement | null>(null);
@@ -323,6 +335,8 @@ export const Tooltip: FC<TooltipProps> = ({
                 update={updatePopover}
                 zIndex={zIndex}
                 fallbackPlacements={fallbackPlacements}
+                preventOverflow={preventOverflow}
+                availableHeight={availableHeight}
             >
                 <div {...getContentProps()}>{content}</div>
             </Popover>

--- a/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/tooltip/src/__snapshots__/Component.test.tsx.snap
@@ -99,10 +99,14 @@ Object {
           style="transition-duration: 150ms;"
         >
           <div
-            class="component"
+            class=""
           >
-            <div>
-              I am tooltip
+            <div
+              class="component"
+            >
+              <div>
+                I am tooltip
+              </div>
             </div>
           </div>
           <div
@@ -204,10 +208,14 @@ Object {
           style="transition-duration: 150ms;"
         >
           <div
-            class="component"
+            class=""
           >
-            <div>
-              I am tooltip
+            <div
+              class="component"
+            >
+              <div>
+                I am tooltip
+              </div>
             </div>
           </div>
           <div

--- a/packages/tooltip/src/docs/description.mdx
+++ b/packages/tooltip/src/docs/description.mdx
@@ -63,6 +63,37 @@ import { InformationCircleMIcon } from '@alfalab/icons-glyph/InformationCircleMI
 </div>
 ```
 
+В случае если тултип не помещается в видимой области экрана, можно передать параметр availableHeight, чтобы компонент подстроил свою высоту под край экрана
+Для position left и right необходимо дополнительно передать параметр preventOverflow = false.
+
+```tsx live
+<div
+    style={{
+        width: '100%',
+        height: '300px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    }}
+>
+    <Tooltip
+        position='left'
+        trigger='click'
+        preventOverflow={ false }
+        availableHeight={ true }
+        content={
+            <div style={{ width: '215px', lineHeight: '1000px' }}>
+                Теперь вам можно снимать наличные в кассе и банкоматах, если ваш тариф это позволяет
+            </div>
+        }
+    >
+        <div style={{ padding: '15px', border: '1px dashed rgba(0, 0, 0, 0.1)' }}>
+            Нажми на меня
+        </div>
+    </Tooltip>
+</div>
+```
+
 ### Также возможен вид `Hint`.
 
 ```tsx live

--- a/yarn.lock
+++ b/yarn.lock
@@ -18178,6 +18178,11 @@ polished@^4.0.5:
   dependencies:
     "@babel/runtime" "^7.14.0"
 
+popper-max-size-modifier@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz#1574744401296a488b4974909d130a85db94256f"
+  integrity sha1-FXR0RAEpakiLSXSQnRMKhduUJW8=
+
 portfinder@^1.0.25, portfinder@^1.0.26:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
# Опишите проблему
Если в tooltip/popover послать большой контент, то компонент просто вылезает за границы экрана и чтобы просмотреть его весь необходимо скролить всю страницу целиком. В случаях, когда не предполагается скролл всей страницы, это выглядит как проблема.

# Ожидаемое поведение
При передаче в Tooltip или Popover пропса availableHeight = true, компонент подстраивает свою высоту под границы экрана и позволяет скроллить контент внутри себя
