### PR TITLE
feat(select): add component to render option content

### DIFF
--- a/packages/select/src/components/option/Component.tsx
+++ b/packages/select/src/components/option/Component.tsx
@@ -17,7 +17,11 @@ export const Option: FC<OptionProps> = ({
     innerProps,
     dataTestId,
 }) => {
-    const content = children || option.content || option.key;
+    const content =
+        children ||
+        option.contentComponent?.({ value: option.value, key: option.key }) ||
+        option.content ||
+        option.key;
 
     return (
         <div

--- a/packages/select/src/typings.ts
+++ b/packages/select/src/typings.ts
@@ -22,6 +22,13 @@ export type OptionShape = {
     content?: ReactNode;
 
     /**
+     * Компонент, который отрисовывает контент в выпадающем списке и в поле при выборе
+     * на основе дополнительных данных
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    contentComponent?: FC<{ value?: any; key: string }>;
+
+    /**
      * Блокирует данный пункт для выбора
      */
     disabled?: boolean;

--- a/packages/select/src/utils.ts
+++ b/packages/select/src/utils.ts
@@ -19,10 +19,16 @@ export const joinOptions = ({
     if (!options.length) return null;
 
     return options.reduce((acc: Array<ReactNode | string>, option: OptionShape, index: number) => {
-        if (isValidElement(option.content)) {
-            acc.push(cloneElement(option.content, { key: option.key }));
+        const justRenderedContent = option.contentComponent?.({
+            value: option.value,
+            key: option.key,
+        });
+        const content = justRenderedContent || option.content;
+
+        if (isValidElement(content) && !option.contentComponent) {
+            acc.push(cloneElement(content, { key: option.key }));
         } else {
-            acc.push(option.content);
+            acc.push(content);
         }
 
         if (index < options.length - 1) acc.push(', ');


### PR DESCRIPTION
Добавил возможность прокидывать в опциях компонент для рендера контента опции, вместо уже отрендеренного компонента

можно будет делать так
```
export const getOption = (card: Card): OptionShape => ({
    key: card.id,
    value: card,
    contentComponent: CardView,
});
```
