### PR TITLE
fix(notification): убрал word-break: break-all

### DIFF
--- a/packages/toast-plate/src/index.module.css
+++ b/packages/toast-plate/src/index.module.css
@@ -68,8 +68,6 @@
 
 .children {
     @mixin paragraph_primary_small;
-
-    word-break: break-all;
 }
 
 .title + .children {

--- a/packages/toast-plate/src/index.module.css
+++ b/packages/toast-plate/src/index.module.css
@@ -68,6 +68,8 @@
 
 .children {
     @mixin paragraph_primary_small;
+
+    word-break: break-word;
 }
 
 .title + .children {


### PR DESCRIPTION
# Опишите проблему
В нотификациях ломается перенос слов

# Шаги для воспроизведения
1. Вызвать нотиф с текстом, например: 'Вебирите доступную дату получения'
2. Перенос будет осуществлен с разбиением слова "получения"

# Ожидаемое поведение
Перенос происходит только на границах слов
