### PR TITLE
fix(TitleResponsive): small view text size

### DIFF
--- a/packages/typography/src/title-responsive/index.module.css
+++ b/packages/typography/src/title-responsive/index.module.css
@@ -16,7 +16,7 @@
 }
 
 .styrene-small {
-    @mixin headline_xsmall;
+    @mixin headline_small;
 }
 
 .styrene-xsmall {


### PR DESCRIPTION
# Опишите проблему
Возможно так и задумывалось, но у Typography.TitleResponsive с view small и medium одинаковый размер. Похоже на баг
