### PR TITLE
fix(icon-view): fix types

### DIFF
--- a/packages/icon-view/src/components/circle/component.tsx
+++ b/packages/icon-view/src/components/circle/component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 
 import { pathsMap } from './paths';
 import { BaseShape, BaseShapeProps } from '../base-shape';
@@ -9,6 +9,11 @@ export type CircleProps = Omit<BaseShapeProps, 'pathsMap' | 'size'> & {
      * @default 64
      */
     size?: 48 | 64 | 80;
+
+    /**
+     * Дочерний компонент
+     */
+    children?: ReactNode;
 };
 
 export const Circle = forwardRef<HTMLDivElement, CircleProps>((props, ref) => (

--- a/packages/icon-view/src/components/super-ellipse/component.tsx
+++ b/packages/icon-view/src/components/super-ellipse/component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ReactNode } from 'react';
 
 import { pathsMap } from './paths';
 import { BaseShape, BaseShapeProps } from '../base-shape';
@@ -9,6 +9,11 @@ export type SuperEllipseProps = Omit<BaseShapeProps, 'pathsMap' | 'size'> & {
      * @default 64
      */
     size?: 48 | 64 | 80 | 128;
+
+    /**
+     * Дочерний компонент
+     */
+    children?: ReactNode;
 };
 
 export const SuperEllipse = forwardRef<HTMLDivElement, SuperEllipseProps>((props, ref) => (


### PR DESCRIPTION
По чистой случайности заметил, что типы как-то криво собираются, пришлось явно указывать `children` в пропсах.

Ниже скриншот, как типы собирались до фикса (там нет children):

<img width="610" alt="Снимок экрана 2022-01-25 в 15 39 35" src="https://user-images.githubusercontent.com/16844982/150981935-facf7007-df2f-4af8-9669-953d153f45c5.png">
 