### PR TITLE
fix(picker-button): fixed type of picker-button size prop

### DIFF
--- a/packages/picker-button/src/Component.tsx
+++ b/packages/picker-button/src/Component.tsx
@@ -15,7 +15,7 @@ import styles from './index.module.css';
 
 const SIDE_POSITIONS = ['right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'];
 
-export type PickerButtonSize = 'xs' | 's' | 'm';
+export type PickerButtonSize = 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl';
 
 export type PickerButtonProps = Omit<
     BaseSelectProps,


### PR DESCRIPTION
Now picker-button size prop can take values: 'xxs', 'xs', 's', 'm', 'l', 'xl'

fix #986 