### PR TITLE
fix(skeleton): added dataTestId

### DIFF
--- a/packages/skeleton/src/Component.tsx
+++ b/packages/skeleton/src/Component.tsx
@@ -40,5 +40,5 @@ export const Skeleton: React.FC<SkeletonProps> = ({
         );
     }
 
-    return <div>{children}</div>;
+    return <div data-test-id={dataTestId}>{children}</div>;
 };


### PR DESCRIPTION
Если `visible !== true`, то `dataTestId` не передается в `div`