### PR TITLE
fix(radio-group): add missing 'value' attribute to 'input' tag

### DIFF
--- a/packages/radio-group/src/Component.test.tsx
+++ b/packages/radio-group/src/Component.test.tsx
@@ -17,13 +17,13 @@ const Group = ({ ...restProps }: Partial<RadioGroupProps>) => (
 
 const TagGroup = ({ ...restProps }: Partial<RadioGroupProps>) => (
     <RadioGroup label='Заголовок группы' type='tag' {...restProps}>
-        <Tag name='one' className='my-tag'>
+        <Tag value='one' className='my-tag'>
             Первый вариант
         </Tag>
 
-        <Tag name='two'>Второй вариант</Tag>
+        <Tag value='two'>Второй вариант</Tag>
 
-        <Tag name='three'>Третий вариант</Tag>
+        <Tag value='three'>Третий вариант</Tag>
     </RadioGroup>
 );
 

--- a/packages/radio-group/src/Component.tsx
+++ b/packages/radio-group/src/Component.tsx
@@ -153,6 +153,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
                         name={name}
                         checked={checked}
                         className={styles.hiddenInput}
+                        value={child.props.value}
                     />
                 </label>
             );

--- a/packages/radio-group/src/__snapshots__/Component.test.tsx.snap
+++ b/packages/radio-group/src/__snapshots__/Component.test.tsx.snap
@@ -581,6 +581,7 @@ Object {
             <button
               class="component component s my-tag"
               type="button"
+              value="one"
             >
               <span>
                 Первый вариант
@@ -590,6 +591,7 @@ Object {
               autocomplete="off"
               class="hiddenInput"
               type="radio"
+              value="one"
             />
           </label>
           <label
@@ -598,6 +600,7 @@ Object {
             <button
               class="component component s"
               type="button"
+              value="two"
             >
               <span>
                 Второй вариант
@@ -607,6 +610,7 @@ Object {
               autocomplete="off"
               class="hiddenInput"
               type="radio"
+              value="two"
             />
           </label>
           <label
@@ -615,6 +619,7 @@ Object {
             <button
               class="component component s"
               type="button"
+              value="three"
             >
               <span>
                 Третий вариант
@@ -624,6 +629,7 @@ Object {
               autocomplete="off"
               class="hiddenInput"
               type="radio"
+              value="three"
             />
           </label>
         </div>
@@ -648,6 +654,7 @@ Object {
           <button
             class="component component s my-tag"
             type="button"
+            value="one"
           >
             <span>
               Первый вариант
@@ -657,6 +664,7 @@ Object {
             autocomplete="off"
             class="hiddenInput"
             type="radio"
+            value="one"
           />
         </label>
         <label
@@ -665,6 +673,7 @@ Object {
           <button
             class="component component s"
             type="button"
+            value="two"
           >
             <span>
               Второй вариант
@@ -674,6 +683,7 @@ Object {
             autocomplete="off"
             class="hiddenInput"
             type="radio"
+            value="two"
           />
         </label>
         <label
@@ -682,6 +692,7 @@ Object {
           <button
             class="component component s"
             type="button"
+            value="three"
           >
             <span>
               Третий вариант
@@ -691,6 +702,7 @@ Object {
             autocomplete="off"
             class="hiddenInput"
             type="radio"
+            value="three"
           />
         </label>
       </div>


### PR DESCRIPTION
Добавлен отсутствубщий атрибут `value` для тега `input`, который рендерится внутри компонента `RadioGroup` при использовании с компонентом `Tag`.

fixes #1031